### PR TITLE
change shelly tag to cloudshell

### DIFF
--- a/onyxia-api/src/main/resources/universe-internal.json
+++ b/onyxia-api/src/main/resources/universe-internal.json
@@ -28,7 +28,7 @@
         },
         "assets": {
           "container": {
-            "docker": { "shelly": "inseefrlab/shelly" }
+            "docker": { "shelly": "inseefrlab/shelly:cloudshell" }
           }
         }
       },


### PR DESCRIPTION
the shelly docker tag for the onyxia cloudshell is now cloudshell (inseefrlab/shelly:cloudshell) so that it contains more functionalities that are cloudshell specific (for now s3cmd, vault, kubectl and helm)