### PR TITLE
Add onykub

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubClient.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubClient.java
@@ -1,0 +1,15 @@
+package fr.insee.onyxia.api.configuration.kubernetes;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KubClient {
+
+    @Bean
+    public KubernetesClient kubernetesClient() {
+        return new DefaultKubernetesClient();
+    }
+}

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/kubernetes/ClusterPermissionsController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/kubernetes/ClusterPermissionsController.java
@@ -1,0 +1,60 @@
+package fr.insee.onyxia.api.controller.api.kubernetes;
+
+import fr.insee.onyxia.api.services.UserProvider;
+import fr.insee.onyxia.api.services.impl.kubernetes.KubernetesService;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Tag(name = "Kubernetes permissions", description = "Manage user access to Kubernetes")
+@RequestMapping("/kubernetes/permissions")
+@RestController
+@SecurityRequirement(name = "auth")
+@ConditionalOnProperty(name = "kubernetes.enabled", havingValue = "true")
+public class ClusterPermissionsController {
+
+    @Autowired
+    private KubernetesService kubernetesService;
+
+    @Autowired
+    private UserProvider userProvider;
+
+    @GetMapping
+    public List<String> getNamespaces() {
+        List<String> userNamespaces;
+        userNamespaces = kubernetesService.getNamespaces(getOwnerFromUser()).stream().map(namespace -> namespace.getMetadata().getName()).collect(Collectors.toList());
+        return userNamespaces;
+    }
+
+    @PostMapping
+    public void createNamespace(@RequestBody CreateNamespaceRequest request) {
+        kubernetesService.createNamespace(request.getNamespaceName(), getOwnerFromUser());
+    }
+
+
+    private KubernetesService.Owner getOwnerFromUser() {
+        KubernetesService.Owner owner = new KubernetesService.Owner();
+        owner.setId(userProvider.getUser().getIdep());
+        owner.setType(KubernetesService.Owner.OwnerType.USER);
+        return owner;
+    }
+
+    public static class CreateNamespaceRequest {
+
+        private String namespaceName;
+
+        public String getNamespaceName() {
+            return namespaceName;
+        }
+
+        public void setNamespaceName(String namespaceName) {
+            this.namespaceName = namespaceName;
+        }
+    }
+}

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
@@ -6,7 +6,6 @@ import io.fabric8.kubernetes.api.model.rbac.DoneableRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,9 +16,6 @@ public class KubernetesService {
 
     @Autowired
     KubernetesClient kubClient;
-
-    @Value("${kubernetes.cluster.user.prefix:}")
-    private String userPrefix;
 
     public void createNamespace(String namespaceId, Owner owner) {
         // Label onyxia_owner is not resilient if the user has "namespace admin" role scoped to his namespace

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
@@ -1,0 +1,81 @@
+package fr.insee.onyxia.api.services.impl.kubernetes;
+
+import io.fabric8.kubernetes.api.model.DoneableNamespace;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.rbac.DoneableRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.SubjectBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class KubernetesService {
+
+    @Autowired
+    KubernetesClient kubClient;
+
+    @Value("${kubernetes.cluster.user.prefix:}")
+    private String userPrefix;
+
+    public void createNamespace(String namespaceId, Owner owner) {
+        // Label onyxia_owner is not resilient if the user has "namespace admin" role scoped to his namespace
+        // as it this rolebinding allows him to modify onyxia_owner metadata
+        DoneableNamespace namespaceToCreate = kubClient.namespaces().createNew().withNewMetadata().withName(namespaceId)
+                .addToLabels("onyxia_owner", owner.getId()).endMetadata();
+
+        DoneableRoleBinding bindingToCreate = kubClient.rbac().roleBindings().inNamespace(namespaceId).createNew()
+                .withNewMetadata()
+                .withLabels(Map.of("createdby","onyxia"))
+                .withName("full_control_namespace").withNamespace(namespaceId).endMetadata()
+                .withSubjects(new SubjectBuilder().withKind(getSubjectKind(owner)).withName(owner.getId())
+                        .withApiGroup("rbac.authorization.k8s.io").withNamespace(namespaceId).build())
+                .withNewRoleRef().withApiGroup("rbac.authorization.k8s.io").withKind("ClusterRole").withName("cluster-admin").endRoleRef();
+
+        // TODO : create all in a single transaction if possible
+        Namespace namespace = namespaceToCreate.done();
+        bindingToCreate.done();
+    }
+
+    public List<Namespace> getNamespaces(Owner owner) {
+        return kubClient.namespaces().withLabel("onyxia_owner",owner.getId()).list().getItems();
+    }
+
+    private String getSubjectKind(Owner owner) {
+        if (owner.getType() == Owner.OwnerType.GROUP) {
+            return "Group";
+        } else if (owner.getType() == Owner.OwnerType.USER) {
+            return "User";
+        }
+        throw new IllegalArgumentException("Owner type must be one of : USER, GROUP");
+    }
+
+    public static class Owner {
+        private String id;
+        private OwnerType type;
+
+        public static enum OwnerType {
+            USER, GROUP;
+        }
+
+        public OwnerType getType() {
+            return type;
+        }
+
+        public void setType(OwnerType type) {
+            this.type = type;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+}


### PR DESCRIPTION
This adds new endpoints for kubernetes management.  
Thoses endpoints are enabled only when using Kubernetes (`kubernetes.enabled=true`).  

The goal is to provide basic namespace management, mostly allowing users to create namespaces with their permissions attached to it.  
This will also be used to create the namespace Onyxia will be deploying apps to.