### PR TITLE
Upgrade helm version

### DIFF
--- a/onyxia-api/Dockerfile
+++ b/onyxia-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM curlimages/curl as build  
 RUN curl -o /tmp/kubectl -L https://storage.googleapis.com/kubernetes-release/release/v1.18.1/bin/linux/amd64/kubectl
-RUN curl -o /tmp/helm -L https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz
+RUN curl -o /tmp/helm -L https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz
 RUN tar -xvzf /tmp/helm -C /tmp
 
 FROM openjdk:11-jre-slim


### PR DESCRIPTION
Helm `3.2.0` has just been released and adds support for `--kube-token` & `--kube-apiserver` options.  
This could allow us to deploy services using User's credentials instead of Onyxia's credentials