### PR TITLE
Use new helm repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ docker run -p 8080:8080 --env "regions=$(<conf.json)" inseefrlab/onyxia-api
 Catalogs configuration  
 | Key | Default | Description |
 | --------------------- | ------- | ------------------------------------------------------------------ |
-| `catalogs.configuration` | `classpath:multiverse.json` | Catalogs to use. Defaults to [multiverse.json](onyxia-api/src/main/resources/multiverse.json). `http://`, `https://` and `file:` schemes are supported |  
+| `catalogs.configuration` | `classpath:catalogs.json` | Catalogs to use. Defaults to [catalogs.json](onyxia-api/src/main/resources/catalogs.json). `http://`, `https://` and `file:` schemes are supported |  
 | `catalogs.refresh.ms` | `300000` (5 minutes) | The rate at which the catalogs should be refreshed. `<= 0` means no refreshs after initial loading |
 
 Other configurations

--- a/onyxia-api/src/main/resources/application.properties
+++ b/onyxia-api/src/main/resources/application.properties
@@ -12,7 +12,7 @@ keycloak.bearer-only=true
 keycloak.disable-trust-manager=false
 
 # Catalogs
-catalogs.configuration=classpath:multiverse.json
+catalogs.configuration=classpath:catalogs.json
 catalogs.refresh.ms=300000
 
 # Debug

--- a/onyxia-api/src/main/resources/catalogs.json
+++ b/onyxia-api/src/main/resources/catalogs.json
@@ -28,9 +28,9 @@
       "type": "universe"
     },
     {
-      "id": "inseefrlab-helm-charts",
-      "name": "Inseefrlab helm charts",
-      "description": "WIP : Various apps",
+      "id": "inseefrlab-helm-charts-datascience",
+      "name": "Inseefrlab datascience",
+      "description": "Services for datascientists. https://github.com/InseeFrLab/helm-charts-datascience",
       "maintainer": "innovation@insee.fr",
       "location": "https://inseefrlab.github.io/helm-charts",
       "status": "PROD",

--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -1,13 +1,13 @@
 {
-  "regions" : [
+  "regions": [
     {
       "regionId": "kub",
       "type": "KUBERNETES",
       "namespace-prefix": "user-",
       "publish-domain": "fakedomain.kub.example.com",
-      "cloudshell" : {
-        "catalogId" : "inseefrlab-helm-charts",
-        "packageName" : "cloudshell"
+      "cloudshell": {
+        "catalogId": "inseefrlab-helm-charts-datascience",
+        "packageName": "cloudshell"
       }
     }
   ]


### PR DESCRIPTION
This PR changes the default Helm repo from https://github.com/InseeFrLab/helm-charts  
to https://github.com/InseeFrLab/helm-charts-datascience  