### PR TITLE
Catalogs configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,95 +69,15 @@ CORS configuration :
 | `cors.allowed_origins` | `*` | To indicate which origins are allowed by [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) |
 
 Regions configuration :
-
-The env variable that configures regions is `regions`.  
-A valid `JSON` is expected with a list of `region` :
-
-```JSON
-[
-   {
-      "id":"eu-west-1",
-      "name":"eu-west-1",
-      "description": "Onyxia supports Marathon but you need to set the credentials to connect to the API.",
-      "services":{
-         "type":"MARATHON",
-         "namespacePrefix":"users",
-         "server":{
-            "URL":"https://marathon.example.com",
-            "auth":{
-               "token":"XYZ"
-            }
-         },
-         "expose":{
-            "domain":"example.example.com"
-         },
-         "monitoring":{
-            "URLPattern":"https://graphana.example.com/$appIdSlug"
-         },
-         "cloudshell":{
-            "catalogId":"internal",
-            "packageName":"shelly"
-         }
-      },
-      "data":{
-         "S3":{
-            "url":"https://minio.example.com"
-         }
-      },
-      "auth":{
-         "type":"openidconnect"
-      },
-      "location":{
-         "lat":48.8164,
-         "long":2.3174,
-         "name":"Paris (France)"
-      }
-   },
-   {
-      "id":"in-cluster",
-      "name":"In cluster",
-      "description": "For kubernetes, you can either set the credentials yourself or use the default in-cluster configuration.",
-      "services":{
-         "type":"KUBERNETES",
-         "namespacePrefix":"user-",
-         "expose":{
-            "domain":"example2.example.com"
-         },
-         "cloudshell":{
-            "catalogId":"inseefrlab-helm-charts-datascience",
-            "packageName":"cloudshell"
-         }
-      },
-      "data":{
-         "S3":{
-            "URL":"https://s3.example.com",
-            "monitoring": {
-              "URLPattern": "https://graphana.s3.example.com/$bucketId"
-            }
-         }
-      },
-      "auth":{
-         "type":"openidconnect"
-      },
-      "location":{
-         "name":"St. Ghislain (Belgium)",
-         "lat":50.8503,
-         "long":4.3517
-      }
-   }
-]
-```
-
-when using docker, passing json as env can be done using :
-
-```shell
-docker run -p 8080:8080 --env "regions=$(<conf.json)" inseefrlab/onyxia-api
-```
-
-Catalogs configuration  
 | Key | Default | Description |
 | --------------------- | ------- | ------------------------------------------------------------------ |
-| `catalogs.configuration` | `classpath:catalogs.json` | Catalogs to use. Defaults to [catalogs.json](onyxia-api/src/main/resources/catalogs.json). `http://`, `https://` and `file:` schemes are supported |  
+| `regions` | see [onyxia-api/src/main/resources/regions.json](onyxia-api/src/main/resources/regions.json) | List of regions. Each region can be of type `KUBERNETES` or `MARATHON`. Mixing is supported. For `KUBERNETES`, `in-cluster` configuration is possible |
+
+Catalogs configuration :  
+
+| Key | Default | Description |
+| --------------------- | ------- | ------------------------------------------------------------------ |
+| `catalogs` | see [onyxia-api/src/main/resources/catalogs.json](onyxia-api/src/main/resources/catalogs.json) | List of catalogs. Each catalog can be of type `universe` or `helm`. Mixing is supported. If there is no region of corresponding type then the catalog will be ignored |
 | `catalogs.refresh.ms` | `300000` (5 minutes) | The rate at which the catalogs should be refreshed. `<= 0` means no refreshs after initial loading |
 
 HTTP configuration  

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
@@ -2,13 +2,12 @@ package fr.insee.onyxia.api.configuration;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import fr.insee.onyxia.model.catalog.Catalog;
 import fr.insee.onyxia.model.catalog.CatalogStatus;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CatalogWrapper {
 
-    private Catalog catalog;
+    private fr.insee.onyxia.model.catalog.CatalogWrapper catalog;
     private String id;
     private String name;
     private String description;
@@ -33,14 +32,14 @@ public class CatalogWrapper {
     /**
      * @return the catalog
      */
-    public Catalog getCatalog() {
+    public fr.insee.onyxia.model.catalog.CatalogWrapper getCatalog() {
         return catalog;
     }
 
     /**
      * @param catalog the catalog to set
      */
-    public void setCatalog(Catalog catalog) {
+    public void setCatalog(fr.insee.onyxia.model.catalog.CatalogWrapper catalog) {
         this.catalog = catalog;
     }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogsLoader.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogsLoader.java
@@ -1,6 +1,7 @@
 package fr.insee.onyxia.api.configuration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.insee.onyxia.api.configuration.properties.CatalogsConfiguration;
 import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
 import fr.insee.onyxia.model.region.Region;
 import org.slf4j.Logger;
@@ -27,25 +28,22 @@ public class CatalogsLoader {
     @Autowired
     private ObjectMapper mapper;
 
-    @Value("${catalogs.configuration}")
-    private String catalogsConf;
-
     @Autowired
     private CatalogFilter catalogFilter;
+
+    @Autowired
+    private CatalogsConfiguration catalogsConfiguration;
 
     private static Logger logger = LoggerFactory.getLogger(CatalogsLoader.class);
 
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
     public Catalogs catalogs() {
-        try (InputStream inputStream = resourceLoader.getResource(catalogsConf).getInputStream()) {
-            Catalogs catalogs = mapper.readValue(inputStream, Catalogs.class);
-            catalogs.setCatalogs(catalogFilter.filterCatalogs(catalogs.getCatalogs()));
-            return catalogs;
-        } catch (Exception e) {
-            logger.error("Error : Could not load catalogs !", e);
-        }
-        return new Catalogs();
+        Catalogs catalogs = new Catalogs();
+        catalogs.setCatalogs(catalogsConfiguration.getResolvedCatalogs());
+        catalogs.setCatalogs(catalogFilter.filterCatalogs(catalogs.getCatalogs()));
+        logger.info("Serving "+catalogs.getCatalogs().size()+" catalogs");
+        return catalogs;
     }
 
     @Service

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfiguration.java
@@ -2,7 +2,7 @@ package fr.insee.onyxia.api.configuration.properties;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import fr.insee.onyxia.model.region.Region;
+import fr.insee.onyxia.api.configuration.CatalogWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -16,44 +16,40 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Configuration
-@PropertySource(value = "classpath:regions.json",factory = RegionsConfiguration.JsonLoader.class)
-@PropertySource(value = "classpath:regions-default.json",factory = RegionsConfiguration.JsonLoader.class,ignoreResourceNotFound = true)
+@PropertySource(value = "classpath:catalogs.json",factory = CatalogsConfiguration.JsonLoader.class)
+@PropertySource(value = "classpath:catalogs-default.json",factory = CatalogsConfiguration.JsonLoader.class,ignoreResourceNotFound = true)
 @ConfigurationProperties
-public class RegionsConfiguration {
+public class CatalogsConfiguration {
 
-    private String regions;
+    private String catalogs;
 
-    private List<Region> resolvedRegions;
+    private List<CatalogWrapper> resolvedCatalogs;
 
     @Autowired
     private ObjectMapper mapper;
 
     @PostConstruct
     public void load() throws Exception {
-        resolvedRegions = Arrays.asList(mapper.readValue(regions, Region[].class));
+        resolvedCatalogs = Arrays.asList(mapper.readValue(catalogs, CatalogWrapper[].class));
+        System.out.println("Serving "+resolvedCatalogs.size()+" catalogs");
     }
 
-    public Optional<Region> getRegionById(String regionId) {
-        return resolvedRegions.stream().filter(region -> region.getId().equals(regionId)).findFirst();
+    public List<CatalogWrapper> getResolvedCatalogs() {
+        return resolvedCatalogs;
     }
 
-    public Region getDefaultRegion() {
-        return resolvedRegions.get(0);
+    public String getCatalogs() {
+        return catalogs;
     }
 
-    public String getRegions() {
-        return regions;
+    public void setCatalogs(String catalogs) {
+        this.catalogs = catalogs;
     }
 
-    public void setRegions(String regions) {
-        this.regions = regions;
-    }
-
-    public List<Region> getResolvedRegions() {
-        return resolvedRegions;
+    public void setResolvedCatalogs(List<CatalogWrapper> resolvedCatalogs) {
+        this.resolvedCatalogs = resolvedCatalogs;
     }
 
     public static class JsonLoader implements PropertySourceFactory {
@@ -62,7 +58,7 @@ public class RegionsConfiguration {
         public org.springframework.core.env.PropertySource<?> createPropertySource(String name,
                                                                                    EncodedResource resource) throws IOException {
             JsonNode values = new ObjectMapper().readTree(resource.getInputStream());
-            return new MapPropertySource("regions-source", Map.of("regions",values.get("regions").toString()));
+            return new MapPropertySource("catalogs-source", Map.of("catalogs",values.get("catalogs").toString()));
         }
 
     }

--- a/onyxia-api/src/main/resources/catalogs.json
+++ b/onyxia-api/src/main/resources/catalogs.json
@@ -19,6 +19,15 @@
       "type": "universe"
     },
     {
+      "id": "inseefrlab-training",
+      "name": "Trainings",
+      "description": "Various trainings for datascientists. https://github.com/inseefrlab/universe-formations",
+      "maintainer": "innovation@insee.fr",
+      "location": "https://inseefrlab.github.io/Universe-Formations/universe.json ",
+      "status": "TEST",
+      "type": "universe"
+    },
+    {
       "id": "inseefrlab-catalog-wip",
       "name": "Datascience catalog WIP",
       "description": "WIP for services for datascientists. https://github.com/InseeFrLab/Universe-Datascience branch Test",

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/catalog/CatalogWrapper.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/catalog/CatalogWrapper.java
@@ -2,7 +2,7 @@ package fr.insee.onyxia.model.catalog;
 
 import java.util.List;
 
-public abstract class Catalog {
+public abstract class CatalogWrapper {
 
     private List<Package> packages;
 

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/catalog/Universe.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/catalog/Universe.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Universe extends Catalog {
+public class Universe extends CatalogWrapper {
 
     public static final String TYPE_UNIVERSE = "universe";
 

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/helm/Repository.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/helm/Repository.java
@@ -4,7 +4,6 @@ package fr.insee.onyxia.model.helm;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -12,12 +11,11 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
-import fr.insee.onyxia.model.catalog.Catalog;
+import fr.insee.onyxia.model.catalog.CatalogWrapper;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Repository extends Catalog {
+public class Repository extends CatalogWrapper {
 
     public static final String TYPE_HELM = "helm";
 


### PR DESCRIPTION
Allow overriding catalogs using env variable using the same system as for the `regions`.  
Additionally, add the InseeFrLab trainings catalog to the default configuration.