### PR TITLE
Security improvements 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Security configuration :
 | Key | Default | Description |
 | --------------------- | ------- | ------------------------------------------------------------------ |
 | `security.cors.allowed_origins` |  | To indicate which origins are allowed by [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) |
-| `security.strictmode` | `true` | Enforces some security measures. Helm / Kubectl commands will be done with user permissions. Requires helm `3.4.0+` |
 
 Regions configuration :
 | Key | Default | Description |

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ Open id configuration
 | `keycloak.bearer-only` | `true` | See [Keycloak configuration](https://www.keycloak.org/docs/latest/securing_apps/#_java_adapter_config) |
 | `keycloak.disable-trust-manager` | `false` | See [Keycloak configuration](https://www.keycloak.org/docs/latest/securing_apps/#_java_adapter_config) |
 
-CORS configuration :
+Security configuration :
 | Key | Default | Description |
 | --------------------- | ------- | ------------------------------------------------------------------ |
-| `cors.allowed_origins` | `*` | To indicate which origins are allowed by [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) |
+| `security.cors.allowed_origins` |  | To indicate which origins are allowed by [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) |
+| `security.strictmode` | `true` | Enforces some security measures. Helm / Kubectl commands will be done with user permissions. Requires helm `3.4.0+` |
 
 Regions configuration :
 | Key | Default | Description |

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/configuration/HelmConfiguration.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/configuration/HelmConfiguration.java
@@ -5,6 +5,7 @@ public class HelmConfiguration {
     private String apiserverUrl;
     private String kubeToken;
     private String kubeConfig;
+    private String asKubeUser;
 
     public String getApiserverUrl() {
         return apiserverUrl;
@@ -28,5 +29,13 @@ public class HelmConfiguration {
 
     public void setKubeConfig(String kubeConfig) {
         this.kubeConfig = kubeConfig;
+    }
+
+    public String getAsKubeUser() {
+        return asKubeUser;
+    }
+
+    public void setAsKubeUser(String asKubeUser) {
+        this.asKubeUser = asKubeUser;
     }
 }

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
@@ -29,7 +29,7 @@ public class HelmInstallService {
 
     }
     public HelmInstaller installChart(HelmConfiguration configuration,String chart, String namespace, String name, boolean dryRun, File values,
-            Map<String, String> env,String asUser)
+            Map<String, String> env)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
         String command = "helm install ";
         if (name != null) {

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
@@ -24,28 +24,12 @@ import java.util.stream.Collectors;
 public class HelmInstallService {
 
     private final Logger logger = LoggerFactory.getLogger(HelmInstallService.class);
-    private HelmConfiguration configuration;
 
     public HelmInstallService() {
 
     }
-
-    public HelmInstallService(HelmConfiguration configuration) {
-        this.configuration = configuration;
-    }
-
-    public HelmInstaller installChart(String chart, String namespace, String name, Boolean dryRun, Map<String, String> env)
-            throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        return installChart(chart, namespace, name, dryRun, null, env);
-    }
-
-    public HelmInstaller installChart(String chart, String namespace, String name, boolean dryRun, File values)
-            throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        return installChart(chart, namespace, name, dryRun, values, null);
-    }
-
-    public HelmInstaller installChart(String chart, String namespace, String name, boolean dryRun, File values,
-            Map<String, String> env)
+    public HelmInstaller installChart(HelmConfiguration configuration,String chart, String namespace, String name, boolean dryRun, File values,
+            Map<String, String> env,String asUser)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
         String command = "helm install ";
         if (name != null) {
@@ -69,12 +53,12 @@ public class HelmInstallService {
         return new ObjectMapper().readValue(res, HelmInstaller.class);
     }
 
-    public int uninstaller(String name, String namespace)
+    public int uninstaller(HelmConfiguration configuration, String name, String namespace)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
         return Command.execute(configuration,"helm uninstall " + name + " -n " + namespace).getExitValue();
     }
 
-    public HelmLs[] listChartInstall(String namespace) throws JsonMappingException, InvalidExitValueException,
+    public HelmLs[] listChartInstall(HelmConfiguration configuration, String namespace) throws JsonMappingException, InvalidExitValueException,
             JsonProcessingException, IOException, InterruptedException, TimeoutException {
         String cmd = "helm ls";
         if (namespace != null) {
@@ -84,7 +68,7 @@ public class HelmInstallService {
                 HelmLs[].class);
     }
 
-    public String getManifest(String id, String namespace) {
+    public String getManifest(HelmConfiguration configuration, String id, String namespace) {
         try {
             return Command.execute(configuration,"helm get manifest " + id + " --namespace " + namespace).getOutput().getString();
         } catch (IOException e) {
@@ -97,7 +81,7 @@ public class HelmInstallService {
         return "";
     }
 
-    public String getValues(String id, String namespace) {
+    public String getValues(HelmConfiguration configuration, String id, String namespace) {
         try {
             return Command.executeAndGetResponseAsJson(configuration,"helm get values " + id + " --namespace " + namespace).getOutput().getString();
         } catch (IOException e) {
@@ -125,7 +109,7 @@ public class HelmInstallService {
      * @return
      * @throws MultipleServiceFound
      */
-    public HelmLs getAppById(String appId, String namespace) throws MultipleServiceFound {
+    public HelmLs getAppById(HelmConfiguration configuration, String appId, String namespace) throws MultipleServiceFound {
         try {
             HelmLs[] result = new ObjectMapper()
                     .readValue(Command.executeAndGetResponseAsJson(configuration,"helm list --filter " + appId + " -n " + namespace)

--- a/helm-wrapper/src/test/java/io/github/inseefrlab/helmwrapper/InstallServiceTest.java
+++ b/helm-wrapper/src/test/java/io/github/inseefrlab/helmwrapper/InstallServiceTest.java
@@ -21,7 +21,7 @@ public class InstallServiceTest {
     @Test
     public void shouldListInstalls() throws Exception {
         HelmInstallService helmInstallService = new HelmInstallService();
-        HelmLs[] result = helmInstallService.listChartInstall(null);
+        HelmLs[] result = helmInstallService.listChartInstall(null, null);
         Assertions.assertEquals(1,result.length);
     }
 
@@ -30,8 +30,8 @@ public class InstallServiceTest {
         HelmConfiguration configuration = new HelmConfiguration();
         configuration.setApiserverUrl("https://invaliddomain");
         configuration.setKubeToken("");
-        HelmInstallService helmInstallService = new HelmInstallService(configuration);
-        Assertions.assertThrows(Exception.class,() -> {HelmLs[] result = helmInstallService.listChartInstall(null);});
+        HelmInstallService helmInstallService = new HelmInstallService();
+        Assertions.assertThrows(Exception.class,() -> {HelmLs[] result = helmInstallService.listChartInstall(null, null);});
     }
 
     @SpringBootApplication

--- a/onyxia-api/Dockerfile
+++ b/onyxia-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM curlimages/curl as build  
 RUN curl -o /tmp/kubectl -L https://storage.googleapis.com/kubernetes-release/release/v1.18.9/bin/linux/amd64/kubectl
-RUN curl -o /tmp/helm -L https://get.helm.sh/helm-v3.3.4-linux-amd64.tar.gz
+RUN curl -o /tmp/helm -L https://get.helm.sh/helm-v3.4.0-rc.1-linux-amd64.tar.gz
 RUN tar -xvzf /tmp/helm -C /tmp
 
 FROM openjdk:11-jre-slim

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/SecurityConfig.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/SecurityConfig.java
@@ -6,19 +6,8 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SecurityConfig {
 
-    @Value("${security.strictmode}")
-    private boolean strictmode;
-
-    @Value("${security.cors.allowed_origins}")
+    @Value("${security.cors.allowed_origins:#{null}}")
     private String corsAllowedOrigins;
-
-    public boolean isStrictmode() {
-        return strictmode;
-    }
-
-    public void setStrictmode(boolean strictmode) {
-        this.strictmode = strictmode;
-    }
 
     public String getCorsAllowedOrigins() {
         return corsAllowedOrigins;

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/SecurityConfig.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/SecurityConfig.java
@@ -1,0 +1,30 @@
+package fr.insee.onyxia.api.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SecurityConfig {
+
+    @Value("${security.strictmode}")
+    private boolean strictmode;
+
+    @Value("${security.cors.allowed_origins}")
+    private String corsAllowedOrigins;
+
+    public boolean isStrictmode() {
+        return strictmode;
+    }
+
+    public void setStrictmode(boolean strictmode) {
+        this.strictmode = strictmode;
+    }
+
+    public String getCorsAllowedOrigins() {
+        return corsAllowedOrigins;
+    }
+
+    public void setCorsAllowedOrigins(String corsAllowedOrigins) {
+        this.corsAllowedOrigins = corsAllowedOrigins;
+    }
+}

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
@@ -1,10 +1,12 @@
 package fr.insee.onyxia.api.configuration.kubernetes;
 
+import fr.insee.onyxia.api.configuration.SecurityConfig;
 import fr.insee.onyxia.model.User;
 import fr.insee.onyxia.model.region.Region;
 import io.github.inseefrlab.helmwrapper.configuration.HelmConfiguration;
 import io.github.inseefrlab.helmwrapper.service.HelmInstallService;
 import io.github.inseefrlab.helmwrapper.service.HelmRepoService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -21,6 +23,9 @@ public class HelmClientProvider {
         return new HelmInstallService();
     }
 
+    @Autowired
+    private SecurityConfig securityConfig = new SecurityConfig();
+
 
     public HelmConfiguration getConfiguration(Region region, User user) {
         HelmConfiguration helmConfiguration = new HelmConfiguration();
@@ -36,7 +41,11 @@ public class HelmClientProvider {
         if (region.getServices().getUsernamePrefix() != null) {
             username = region.getServices().getUsernamePrefix()+username;
         }
-        helmConfiguration.setAsKubeUser(username);
+
+        if (securityConfig.isStrictmode()) {
+            helmConfiguration.setAsKubeUser(username);
+        }
+
         return helmConfiguration;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
@@ -42,7 +42,7 @@ public class HelmClientProvider {
             username = region.getServices().getUsernamePrefix()+username;
         }
 
-        if (securityConfig.isStrictmode()) {
+        if (region.getServices().getAuthenticationMode() == Region.Services.AuthenticationMode.IMPERSONATE) {
             helmConfiguration.setAsKubeUser(username);
         }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
@@ -20,12 +20,8 @@ public class HelmClientProvider {
         return new HelmInstallService();
     }
 
-    public HelmInstallService getHelmInstallServiceForRegion(Region region) {
-        return new HelmInstallService(generateConfigurationForRegion(region));
-    }
 
-
-    private HelmConfiguration generateConfigurationForRegion(Region region) {
+    public HelmConfiguration generateConfigurationForRegion(Region region) {
         HelmConfiguration helmConfiguration = new HelmConfiguration();
         if (region.getServices().getServer() != null) {
             Region.Auth auth = region.getServices().getServer().getAuth();

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
@@ -1,5 +1,6 @@
 package fr.insee.onyxia.api.configuration.kubernetes;
 
+import fr.insee.onyxia.model.User;
 import fr.insee.onyxia.model.region.Region;
 import io.github.inseefrlab.helmwrapper.configuration.HelmConfiguration;
 import io.github.inseefrlab.helmwrapper.service.HelmInstallService;
@@ -21,7 +22,7 @@ public class HelmClientProvider {
     }
 
 
-    public HelmConfiguration generateConfigurationForRegion(Region region) {
+    public HelmConfiguration getConfiguration(Region region, User user) {
         HelmConfiguration helmConfiguration = new HelmConfiguration();
         if (region.getServices().getServer() != null) {
             Region.Auth auth = region.getServices().getServer().getAuth();
@@ -31,6 +32,11 @@ public class HelmClientProvider {
             helmConfiguration.setApiserverUrl(region.getServices().getServer().getUrl());
             helmConfiguration.setKubeConfig(null);
         }
+        String username = user.getIdep();
+        if (region.getServices().getUsernamePrefix() != null) {
+            username = region.getServices().getUsernamePrefix()+username;
+        }
+        helmConfiguration.setAsKubeUser(username);
         return helmConfiguration;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
@@ -36,7 +36,7 @@ public class KubernetesClientProvider {
             username = region.getServices().getUsernamePrefix()+user.getIdep();
         }
 
-        if (securityConfig.isStrictmode()) {
+        if (region.getServices().getAuthenticationMode() == Region.Services.AuthenticationMode.IMPERSONATE) {
             config.setImpersonateUsername(username);
             config.setImpersonateGroups(null);
         }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
@@ -1,5 +1,6 @@
 package fr.insee.onyxia.api.configuration.kubernetes;
 
+import fr.insee.onyxia.model.User;
 import fr.insee.onyxia.model.region.Region;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
@@ -13,7 +14,28 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class KubernetesClientProvider {
 
-    public KubernetesClient getClientForRegion(Region region) {
+    /**
+     * This returns the root client which has extended permissions. Currently cluster-admin.
+     * User calls should be done using the userClient which only has user permissions.
+     * @param region
+     * @return
+     */
+    public KubernetesClient getRootClient(Region region) {
+        Config config = getDefaultConfiguration(region).build();
+        return new DefaultKubernetesClient(config);
+    }
+
+    public KubernetesClient getUserClient(Region region, User user) {
+        Config config = getDefaultConfiguration(region).build();
+        String username = user.getIdep();
+        if (region.getServices().getUsernamePrefix() != null) {
+            username = region.getServices().getUsernamePrefix()+user.getIdep();
+        }
+        config.setImpersonateUsername(username);
+        return new DefaultKubernetesClient(config);
+    }
+
+    private ConfigBuilder getDefaultConfiguration(Region region) {
         ConfigBuilder configBuilder = new ConfigBuilder();
         if (region.getServices().getServer() != null && region.getServices().getServer().getUrl() != null) {
             configBuilder.withMasterUrl(region.getServices().getServer().getUrl() );
@@ -31,9 +53,6 @@ public class KubernetesClientProvider {
                 }
             }
         }
-
-        Config config = configBuilder.build();
-        KubernetesClient client = new DefaultKubernetesClient(config);
-        return client;
+        return configBuilder;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
@@ -1,5 +1,6 @@
 package fr.insee.onyxia.api.configuration.kubernetes;
 
+import fr.insee.onyxia.api.configuration.SecurityConfig;
 import fr.insee.onyxia.model.User;
 import fr.insee.onyxia.model.region.Region;
 import io.fabric8.kubernetes.client.Config;
@@ -13,6 +14,9 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class KubernetesClientProvider {
+
+    @Autowired
+    private SecurityConfig securityConfig;
 
     /**
      * This returns the root client which has extended permissions. Currently cluster-admin.
@@ -31,8 +35,12 @@ public class KubernetesClientProvider {
         if (region.getServices().getUsernamePrefix() != null) {
             username = region.getServices().getUsernamePrefix()+user.getIdep();
         }
-        config.setImpersonateUsername(username);
-        config.setImpersonateGroups(null);
+
+        if (securityConfig.isStrictmode()) {
+            config.setImpersonateUsername(username);
+            config.setImpersonateGroups(null);
+        }
+
         return new DefaultKubernetesClient(config);
     }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
@@ -32,6 +32,7 @@ public class KubernetesClientProvider {
             username = region.getServices().getUsernamePrefix()+user.getIdep();
         }
         config.setImpersonateUsername(username);
+        config.setImpersonateGroups(null);
         return new DefaultKubernetesClient(config);
     }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
@@ -1,6 +1,8 @@
 package fr.insee.onyxia.api.security;
 
+import fr.insee.onyxia.api.configuration.SecurityConfig;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -9,13 +11,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class DisableCORS implements WebMvcConfigurer {
 
-    @Value("${security.cors.allowed_origins:#{null}}")
-    private String corsAllowedOrigins;
+    @Autowired
+    private SecurityConfig securityConfig;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        if (StringUtils.isNotEmpty(corsAllowedOrigins)) {
-            registry.addMapping("/**").allowedOrigins(corsAllowedOrigins).allowedMethods("*");
+        if (StringUtils.isNotEmpty(securityConfig.getCorsAllowedOrigins())) {
+            registry.addMapping("/**").allowedOrigins(securityConfig.getCorsAllowedOrigins()).allowedMethods("*");
         }
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class DisableCORS implements WebMvcConfigurer {
 
-    @Value("${securityy.cors.allowed_origins}")
+    @Value("${security.cors.allowed_origins:#{null}}")
     private String corsAllowedOrigins;
 
     @Override

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class DisableCORS implements WebMvcConfigurer {
 
-    @Value("${cors.allowed_origins}")
+    @Value("${securityy.cors.allowed_origins}")
     private String corsAllowedOrigins;
 
     @Override

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -180,7 +180,7 @@ public class HelmAppsService implements AppsService {
 
     @Override
     public String getLogs(Region region,User user, String serviceId, String taskId) {
-        KubernetesClient client = kubernetesClientProvider.getClientForRegion(region);
+        KubernetesClient client = kubernetesClientProvider.getUserClient(region,user);
         return client.pods().inNamespace(determineNamespace(region, region.getServices().getNamespacePrefix(),user)).withName(taskId).getLog();
     }
 
@@ -218,7 +218,7 @@ public class HelmAppsService implements AppsService {
 
     private Service getHelmApp(Region region, User user, HelmLs release) {
         String manifest = getHelmInstallService().getManifest(getHelmConfiguration(region,user),release.getName(), release.getNamespace());
-        Service service = getServiceFromRelease(region, release, manifest);
+        Service service = getServiceFromRelease(region, release, manifest,user);
         service.setStatus(findAppStatus(release));
         try {
             service.setStartedAt(helmDateFormat.parse(release.getUpdated()).getTime());
@@ -252,8 +252,8 @@ public class HelmAppsService implements AppsService {
         }
     }
 
-    private Service getServiceFromRelease(Region region, HelmLs release, String manifest) {
-        KubernetesClient client = kubernetesClientProvider.getClientForRegion(region);
+    private Service getServiceFromRelease(Region region, HelmLs release, String manifest, User user) {
+        KubernetesClient client = kubernetesClientProvider.getUserClient(region,user);
         InputStream inputStream = new ByteArrayInputStream(manifest.getBytes(Charset.forName("UTF-8")));
         List<HasMetadata> hasMetadatas = client.load(inputStream).get();
         List<Ingress> ingresses = hasMetadatas.stream().filter(hasMetadata -> hasMetadata instanceof Ingress)

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
@@ -20,6 +20,10 @@ public class KubernetesService {
     private KubernetesClientProvider kubernetesClientProvider;
 
     public void createNamespace(Region region, String namespaceId, Owner owner) {
+        String username = owner.getId();
+        if (owner.getType() == Owner.OwnerType.USER) {
+            username = region.getServices().getUsernamePrefix()+username;
+        }
         // Label onyxia_owner is not resilient if the user has "namespace admin" role scoped to his namespace
         // as it this rolebinding allows him to modify onyxia_owner metadata
         KubernetesClient kubClient = kubernetesClientProvider.getClientForRegion(region);
@@ -30,7 +34,7 @@ public class KubernetesService {
                 .withNewMetadata()
                 .withLabels(Map.of("createdby","onyxia"))
                 .withName("full_control_namespace").withNamespace(namespaceId).endMetadata()
-                .withSubjects(new SubjectBuilder().withKind(getSubjectKind(owner)).withName(owner.getId())
+                .withSubjects(new SubjectBuilder().withKind(getSubjectKind(owner)).withName(username)
                         .withApiGroup("rbac.authorization.k8s.io").withNamespace(namespaceId).build())
                 .withNewRoleRef().withApiGroup("rbac.authorization.k8s.io").withKind("ClusterRole").withName("cluster-admin").endRoleRef();
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
@@ -26,7 +26,7 @@ public class KubernetesService {
         }
         // Label onyxia_owner is not resilient if the user has "namespace admin" role scoped to his namespace
         // as it this rolebinding allows him to modify onyxia_owner metadata
-        KubernetesClient kubClient = kubernetesClientProvider.getClientForRegion(region);
+        KubernetesClient kubClient = kubernetesClientProvider.getRootClient(region);
         DoneableNamespace namespaceToCreate = kubClient.namespaces().createNew().withNewMetadata().withName(namespaceId)
                 .addToLabels("onyxia_owner", owner.getId()).endMetadata();
 
@@ -44,7 +44,7 @@ public class KubernetesService {
     }
 
     public List<Namespace> getNamespaces(Region region, Owner owner) {
-        KubernetesClient kubClient = kubernetesClientProvider.getClientForRegion(region);
+        KubernetesClient kubClient = kubernetesClientProvider.getRootClient(region);
         return kubClient.namespaces().withLabel("onyxia_owner",owner.getId()).list().getItems();
     }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
@@ -21,7 +21,7 @@ public class KubernetesService {
 
     public void createNamespace(Region region, String namespaceId, Owner owner) {
         String username = owner.getId();
-        if (owner.getType() == Owner.OwnerType.USER) {
+        if (owner.getType() == Owner.OwnerType.USER && region.getServices().getUsernamePrefix() != null) {
             username = region.getServices().getUsernamePrefix()+username;
         }
         // Label onyxia_owner is not resilient if the user has "namespace admin" role scoped to his namespace

--- a/onyxia-api/src/main/resources/application.properties
+++ b/onyxia-api/src/main/resources/application.properties
@@ -14,8 +14,10 @@ keycloak.disable-trust-manager=false
 # Catalogs
 catalogs.refresh.ms=300000
 
-# CORS
-cors.allowed_origins=*
+# Security
+security.cors.allowed_origins=
+security.strictmode=true
+
 
 # Http configuration
 http.proxyHost=

--- a/onyxia-api/src/main/resources/application.properties
+++ b/onyxia-api/src/main/resources/application.properties
@@ -16,8 +16,6 @@ catalogs.refresh.ms=300000
 
 # Security
 security.cors.allowed_origins=
-security.strictmode=true
-
 
 # Http configuration
 http.proxyHost=

--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -13,7 +13,7 @@
         "initScript": "https://git.lab.sspcloud.fr/innovation/plateforme-onyxia/services-ressources/-/raw/master/onyxia-init.sh",
         "namespacePrefix": "user-",
         "usernamePrefix": "oidc-",
-        "authenticationMode" : "impersonate",
+        "authenticationMode" : "admin",
         "expose": {
           "domain": "fakedomain.kub.example.com"
         },

--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -13,6 +13,7 @@
         "initScript": "https://git.lab.sspcloud.fr/innovation/plateforme-onyxia/services-ressources/-/raw/master/onyxia-init.sh",
         "namespacePrefix": "user-",
         "usernamePrefix": "oidc-",
+        "authenticationMode" : "impersonate",
         "expose": {
           "domain": "fakedomain.kub.example.com"
         },

--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -12,6 +12,7 @@
         "network": "calico",
         "initScript": "https://git.lab.sspcloud.fr/innovation/plateforme-onyxia/services-ressources/-/raw/master/onyxia-init.sh",
         "namespacePrefix": "user-",
+        "usernamePrefix": "oidc-",
         "expose": {
           "domain": "fakedomain.kub.example.com"
         },

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/UserControllerTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/UserControllerTest.java
@@ -2,6 +2,7 @@ package fr.insee.onyxia.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fr.insee.onyxia.api.configuration.BaseTest;
+import fr.insee.onyxia.api.configuration.SecurityConfig;
 import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
 import fr.insee.onyxia.api.controller.api.user.UserController;
 import fr.insee.onyxia.api.services.utils.HttpRequestUtils;
@@ -32,6 +33,9 @@ public class UserControllerTest extends BaseTest {
 
    @MockBean
    private RegionsConfiguration regionsConfiguration;
+
+   @MockBean
+   private SecurityConfig securityConfig;
 
    @Test
    public void shouldReturnUserInfo() throws Exception {

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
@@ -1,5 +1,6 @@
 package fr.insee.onyxia.model.region;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import fr.insee.onyxia.model.service.Service;
@@ -73,11 +74,19 @@ public class Region {
     @JsonIgnoreProperties(value={"server"},allowSetters = true)
     public static class Services {
 
+        public static enum AuthenticationMode {
+            @JsonProperty("impersonate")
+            IMPERSONATE,
+            @JsonProperty("admin")
+            ADMIN
+        }
+
         private Service.ServiceType type;
         private boolean defaultIpProtection;
         private String network;
         private String namespacePrefix;
         private String usernamePrefix;
+        private AuthenticationMode authenticationMode = AuthenticationMode.IMPERSONATE;
         private String marathonDnsSuffix;
         private Expose expose;
         private Server server;
@@ -171,6 +180,14 @@ public class Region {
 
         public void setInitScript(String initScript) {
             this.initScript = initScript;
+        }
+
+        public AuthenticationMode getAuthenticationMode() {
+            return authenticationMode;
+        }
+
+        public void setAuthenticationMode(AuthenticationMode authenticationMode) {
+            this.authenticationMode = authenticationMode;
         }
     }
 

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
@@ -77,6 +77,7 @@ public class Region {
         private boolean defaultIpProtection;
         private String network;
         private String namespacePrefix;
+        private String usernamePrefix;
         private String marathonDnsSuffix;
         private Expose expose;
         private Server server;
@@ -114,6 +115,14 @@ public class Region {
 
         public void setNamespacePrefix(String namespacePrefix) {
             this.namespacePrefix = namespacePrefix;
+        }
+
+        public String getUsernamePrefix() {
+            return usernamePrefix;
+        }
+
+        public void setUsernamePrefix(String usernamePrefix) {
+            this.usernamePrefix = usernamePrefix;
         }
 
         public String getMarathonDnsSuffix() {


### PR DESCRIPTION
This PR adds user impersonation for both helm and kubectl.  
New region configuration attribute `authenticationMode` :  
* `admin` : each helm / kubectl calls are done with onyxia-api permissions (cluster-admin). This is the default  
* `impersonate` : each helm / kubectl call (except for onboarding) is done impersonating the user. This is the more secure but not compatible with in-cluster configuration and requires helm 3.4.0+ ( see https://github.com/helm/helm/commit/9429af8b39c6888a41ffa2945d7c73676afb577e#diff-ab0b247f8d73a6afc9c64237096ddb96ca5df0558fe5f5da64f493c2abad4be5)
* Not yet implemented : `userToken` ? : each helm / kubectl call (except for onboarding) is done using the user's token. This is the most secure.  

This PR also adds kubectl user impersonation.
This PR also bumps the docker-bundled helm version to 3.4.0-RC1.
This PR also adds `usernamePrefix` configuration in region.  
This PR also disables CORS by default, `security.cors.allowed_origins` can be set to re-enable it.
