### PR TITLE
Fix bean injection

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityConfiguration.java
@@ -1,22 +1,17 @@
 package fr.insee.onyxia.api.security;
 
-import fr.insee.onyxia.api.services.UserProvider;
 import fr.insee.onyxia.api.services.utils.HttpRequestUtils;
-import fr.insee.onyxia.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
-import org.springframework.context.annotation.Bean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Configuration
 @EnableWebSecurity
-@ConditionalOnSingleCandidate(WebSecurityConfigurerAdapter.class)
+@ConditionalOnExpression("'${authentication.mode}' == 'none' or '${authentication.mode}' == ''")
 public class NoSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityUserProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityUserProvider.java
@@ -4,9 +4,9 @@ import fr.insee.onyxia.api.services.UserProvider;
 import fr.insee.onyxia.api.services.utils.HttpRequestUtils;
 import fr.insee.onyxia.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -17,7 +17,7 @@ public class NoSecurityUserProvider {
     private HttpRequestUtils httpRequestUtils;
 
     @Bean
-    @Primary
+    @ConditionalOnMissingBean
     public UserProvider getUserProvider() {
         return () -> {
             User user = User.newInstance()

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityUserProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityUserProvider.java
@@ -3,21 +3,12 @@ package fr.insee.onyxia.api.security;
 import fr.insee.onyxia.api.services.UserProvider;
 import fr.insee.onyxia.api.services.utils.HttpRequestUtils;
 import fr.insee.onyxia.model.User;
-import org.keycloak.KeycloakSecurityContext;
-import org.keycloak.representations.AccessToken;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnSingleCandidate;
-import org.springframework.context.annotation.*;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.web.context.WebApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.List;
 
 @Configuration
 public class NoSecurityUserProvider {
@@ -26,7 +17,7 @@ public class NoSecurityUserProvider {
     private HttpRequestUtils httpRequestUtils;
 
     @Bean
-    @ConditionalOnMissingBean(UserProvider.class)
+    @Primary
     public UserProvider getUserProvider() {
         return () -> {
             User user = User.newInstance()

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityUserProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/NoSecurityUserProvider.java
@@ -4,20 +4,20 @@ import fr.insee.onyxia.api.services.UserProvider;
 import fr.insee.onyxia.api.services.utils.HttpRequestUtils;
 import fr.insee.onyxia.model.User;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Configuration
+@ConditionalOnExpression("'${authentication.mode}' == 'none' or '${authentication.mode}' == ''")
 public class NoSecurityUserProvider {
 
     @Autowired
     private HttpRequestUtils httpRequestUtils;
 
     @Bean
-    @ConditionalOnMissingBean
     public UserProvider getUserProvider() {
         return () -> {
             User user = User.newInstance()


### PR DESCRIPTION
Since 8fe86d776cd5b36a915ac30420f1e9348a237cdf , we had startup errors due to muliple beans registering when using openidconnect as authentication method.  
Neither 45a149ff2e88a08f06a60d2883936a89d784f10e nor 81cd8733ef4d562f41007cc9575dc610fc9ac4d8 fixed this.  
This PR should fix this error, once and for all :)