### PR TITLE
Remove the default S3 configuration

### DIFF
--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -43,19 +43,7 @@
         }
       },
       "data": {
-        "S3": {
-          "type": "amazon",
-          "url": "",
-          "region": "us-east-1",
-          "roleARN" : "",
-          "roleSessionName" : "",
-          "bucketPrefix": "",
-          "groupBucketPrefix": "",
-          "bucketClaim": "preferred_username",
-          "monitoring": {
-            "URLPattern": "https://graphana.minio.example.com/$bucketId"
-          }
-        }
+       
       },
       "auth": {
         "type": "openidconnect"


### PR DESCRIPTION
Since 37ffb20b001fa55c741e268fd38a1b335c3c26f8, we have a S3 block in the default configuration.  
This block indicates to the client that S3 is configured for this region although the configuration is missing some required fields. This causes the UI to break (see https://github.com/InseeFrLab/onyxia/issues/33 ).  
This PR removes the S3 block from the default configuration.  
We will have to document how to configure it since it will no longer be present in the default configuration.