### PR TITLE
Fix java & helm noproxy variables

### DIFF
--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
@@ -75,8 +75,8 @@ public class Command {
             env.put("HTTPS_PROXY", System.getProperty("https.proxyHost") + (System.getProperty("https.proxyPort") != null ? ":" + System.getProperty("https.proxyPort") : ""));
         }
 
-        if (System.getProperty("no_proxy") != null) {
-            env.put("NO_PROXY", System.getProperty("no_proxy"));
+        if (System.getProperty("noProxy") != null) {
+            env.put("NO_PROXY", System.getProperty("noProxy"));
         }
 
         return env;

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
@@ -75,8 +75,8 @@ public class Command {
             env.put("HTTPS_PROXY", System.getProperty("https.proxyHost") + (System.getProperty("https.proxyPort") != null ? ":" + System.getProperty("https.proxyPort") : ""));
         }
 
-        if (System.getProperty("noProxy") != null) {
-            env.put("NO_PROXY", System.getProperty("noProxy"));
+        if (System.getProperty("http.noProxy") != null) {
+            env.put("NO_PROXY", System.getProperty("http.noProxy"));
         }
 
         return env;

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
@@ -75,8 +75,8 @@ public class Command {
             env.put("HTTPS_PROXY", System.getProperty("https.proxyHost") + (System.getProperty("https.proxyPort") != null ? ":" + System.getProperty("https.proxyPort") : ""));
         }
 
-        if (System.getProperty("http.noProxy") != null) {
-            env.put("NO_PROXY", System.getProperty("http.noProxy"));
+        if (System.getProperty("no_proxy") != null) {
+            env.put("NO_PROXY", System.getProperty("no_proxy"));
         }
 
         return env;

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
@@ -37,7 +37,7 @@ public class SetProxy {
             }
             if (StringUtils.isNotEmpty(noProxy)) {
                 System.out.println("No proxy : " + noProxy);
-                System.setProperty("http.nonProxyHosts", noProxy.replaceAll("\\|", ","));
+                System.setProperty("http.nonProxyHosts", noProxy.replaceAll(",", "\\|"));
                 System.setProperty("no_proxy", noProxy);
             }
             if (StringUtils.isNotEmpty(proxyUsername)) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
@@ -38,7 +38,6 @@ public class SetProxy {
             if (StringUtils.isNotEmpty(noProxy)) {
                 System.out.println("No proxy : " + noProxy);
                 System.setProperty("http.nonProxyHosts", noProxy.replaceAll(",", "\\|"));
-                System.setProperty("no_proxy", noProxy);
             }
             if (StringUtils.isNotEmpty(proxyUsername)) {
                 System.out.println("Proxy username  : " + proxyUsername);

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
@@ -41,7 +41,7 @@ public class SetProxy {
                 System.setProperty("no_proxy", noProxy);
             }
             if (StringUtils.isNotEmpty(proxyUsername)) {
-                System.out.println("Proxy username  : " +proxyUsername);
+                System.out.println("Proxy username  : " + proxyUsername);
                 System.setProperty("http.proxyUser", proxyUsername);
                 if (StringUtils.isNotEmpty(proxyPassword)) {
                     System.setProperty("http.proxyPassword", proxyPassword);

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/proxy/SetProxy.java
@@ -38,9 +38,10 @@ public class SetProxy {
             if (StringUtils.isNotEmpty(noProxy)) {
                 System.out.println("No proxy : " + noProxy);
                 System.setProperty("http.nonProxyHosts", noProxy.replaceAll(",", "\\|"));
+                System.setProperty("no_proxy", noProxy);
             }
             if (StringUtils.isNotEmpty(proxyUsername)) {
-                System.out.println("Proxy username  : " + proxyUsername);
+                System.out.println("Proxy username  : " +proxyUsername);
                 System.setProperty("http.proxyUser", proxyUsername);
                 if (StringUtils.isNotEmpty(proxyPassword)) {
                     System.setProperty("http.proxyPassword", proxyPassword);


### PR DESCRIPTION
- JAVA noproxy variable `http.nonProxyHosts` now recovers `noProxy` and translates every `,` separator into `|`.
- Helm noproxy variable `NO_PROXY` now recovers `http.noProxy` as it is, with `,` separator so it understands it.
- README does not change since it was already updated