### PR TITLE
Enable compression

### DIFF
--- a/onyxia-api/src/main/resources/application.properties
+++ b/onyxia-api/src/main/resources/application.properties
@@ -17,13 +17,16 @@ catalogs.refresh.ms=300000
 # Security
 security.cors.allowed_origins=
 
-# Http configuration
+# Proxy configuration
 http.proxyHost=
 http.proxyPort=
 http.noProxy=
 http.proxyUsername=
 http.proxyPassword=
 
+# Enable compression by default for responses > 1k
+server.compression.enabled=true
+server.compression.min-response-size=1024
 
 # Open API documentation
 springdoc.swagger-ui.path=/


### PR DESCRIPTION
Enable compression by default for all responses > 1kb.  
This is especially useful for reducing data transferred for catalog endpoint