### PR TITLE
Cleanup context path

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/cloudshell/CloudShellController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/cloudshell/CloudShellController.java
@@ -7,11 +7,10 @@ import fr.insee.onyxia.model.catalog.Pkg;
 import fr.insee.onyxia.model.project.Project;
 import fr.insee.onyxia.model.region.Region;
 import fr.insee.onyxia.model.service.Service;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
-
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,86 +18,86 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Cloud Shell", description = "Cloud shell")
-@RequestMapping(value={"/api/cloudshell", "/cloudshell"})
+@RequestMapping("/cloudshell")
 @RestController
-@SecurityRequirement(name="auth")
+@SecurityRequirement(name = "auth")
 public class CloudShellController {
 
-	@Autowired
-	private AppsService helmAppsService;
+    @Autowired
+    private AppsService helmAppsService;
 
-	@Autowired
-	private UserProvider userProvider;
+    @Autowired
+    private UserProvider userProvider;
 
-	@Autowired
-	private CatalogService catalogService;
+    @Autowired
+    private CatalogService catalogService;
 
-	@GetMapping
-	public CloudShellStatus getCloudShellStatus(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project) {
-		CloudShellStatus status = new CloudShellStatus();
-		Region.CloudshellConfiguration cloudshellConfiguration = region.getServices().getCloudshell();
-		try {
-			if (region.getServices().getType().equals(Service.ServiceType.KUBERNETES)) {
-				Service service = helmAppsService.getUserService(region, project, userProvider.getUser(region),
-						cloudshellConfiguration.getPackageName() + "*");
-				status.setStatus(CloudShellStatus.STATUS_UP);
-				service.getUrls().stream().findFirst().ifPresent(status::setUrl);
-			} else {
-				throw new NotImplementedException("Cloudshell is only supported for Kubernetes service provider");
-			}
-		} catch (Exception e) {
-			status.setStatus(CloudShellStatus.STATUS_DOWN);
-			status.setPackageToDeploy(catalogService.getPackage(cloudshellConfiguration.getCatalogId(),cloudshellConfiguration.getPackageName()));
-			status.setCatalogId(cloudshellConfiguration.getCatalogId());
-			status.setUrl(null);
-		}
+    @GetMapping
+    public CloudShellStatus getCloudShellStatus(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project) {
+        CloudShellStatus status = new CloudShellStatus();
+        Region.CloudshellConfiguration cloudshellConfiguration = region.getServices().getCloudshell();
+        try {
+            if (region.getServices().getType().equals(Service.ServiceType.KUBERNETES)) {
+                Service service = helmAppsService.getUserService(region, project, userProvider.getUser(region),
+                        cloudshellConfiguration.getPackageName() + "*");
+                status.setStatus(CloudShellStatus.STATUS_UP);
+                service.getUrls().stream().findFirst().ifPresent(status::setUrl);
+            } else {
+                throw new NotImplementedException("Cloudshell is only supported for Kubernetes service provider");
+            }
+        } catch (Exception e) {
+            status.setStatus(CloudShellStatus.STATUS_DOWN);
+            status.setPackageToDeploy(catalogService.getPackage(cloudshellConfiguration.getCatalogId(), cloudshellConfiguration.getPackageName()));
+            status.setCatalogId(cloudshellConfiguration.getCatalogId());
+            status.setUrl(null);
+        }
 
-		return status;
-	}
+        return status;
+    }
 
-	@Schema(description = "Cloudshell data and health")
-	public static class CloudShellStatus {
+    @Schema(description = "Cloudshell data and health")
+    public static class CloudShellStatus {
 
-		public static final String STATUS_UP = "UP", STATUS_LOADING = "LOADING", STATUS_DOWN = "DOWN";
-		@Schema(description = "Status of the connexion to the cloudshell")
-		private String status = STATUS_UP;
-		@Schema(description = "URL of the cloudshell")
-		private String url = null;
-		@Schema(description = "?")
-		private Pkg packageToDeploy = null;
-		@Schema(description = "?")
-		private String catalogId;
+        public static final String STATUS_UP = "UP", STATUS_LOADING = "LOADING", STATUS_DOWN = "DOWN";
+        @Schema(description = "Status of the connexion to the cloudshell")
+        private String status = STATUS_UP;
+        @Schema(description = "URL of the cloudshell")
+        private String url = null;
+        @Schema(description = "?")
+        private Pkg packageToDeploy = null;
+        @Schema(description = "?")
+        private String catalogId;
 
-		public String getStatus() {
-			return status;
-		}
+        public String getStatus() {
+            return status;
+        }
 
-		public void setStatus(String status) {
-			this.status = status;
-		}
+        public void setStatus(String status) {
+            this.status = status;
+        }
 
-		public String getUrl() {
-			return url;
-		}
+        public String getUrl() {
+            return url;
+        }
 
-		public void setUrl(String url) {
-			this.url = url;
-		}
+        public void setUrl(String url) {
+            this.url = url;
+        }
 
-		public Pkg getPackageToDeploy() {
-			return packageToDeploy;
-		}
+        public Pkg getPackageToDeploy() {
+            return packageToDeploy;
+        }
 
-		public void setPackageToDeploy(Pkg packageToDeploy) {
-			this.packageToDeploy = packageToDeploy;
-		}
+        public void setPackageToDeploy(Pkg packageToDeploy) {
+            this.packageToDeploy = packageToDeploy;
+        }
 
-		public String getCatalogId() {
-			return catalogId;
-		}
+        public String getCatalogId() {
+            return catalogId;
+        }
 
-		public void setCatalogId(String catalogId) {
-			this.catalogId = catalogId;
-		}
-	}
+        public void setCatalogId(String catalogId) {
+            this.catalogId = catalogId;
+        }
+    }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -13,12 +13,12 @@ import fr.insee.onyxia.model.project.Project;
 import fr.insee.onyxia.model.region.Region;
 import fr.insee.onyxia.model.service.Service;
 import fr.insee.onyxia.model.service.UninstallService;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,7 +27,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 @Tag(name = "My lab", description = "My services")
-@RequestMapping(value={"/api/my-lab", "/my-lab"})
+@RequestMapping("/my-lab")
 @RestController
 @SecurityRequirement(name = "auth")
 public class MyLabController {
@@ -41,37 +41,37 @@ public class MyLabController {
     private CatalogService catalogService;
 
     @Operation(
-        summary = "List the services installed in a namespace.",
-        description = "List the services installed in a namespace. With a Kubernetes backend, utilize Helm to list all installed services in a namespace.",
-        parameters = {
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "Generated project id.",
-                    example = "project-id-example"
-                )
-            ),
-            @Parameter(
-                required = false,
-                name = "groupId",
-                description = "Deprectated.",
-                deprecated = true,
-                in = ParameterIn.QUERY
-            )
-        }
+            summary = "List the services installed in a namespace.",
+            description = "List the services installed in a namespace. With a Kubernetes backend, utilize Helm to list all installed services in a namespace.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "Generated project id.",
+                                    example = "project-id-example"
+                            )
+                    ),
+                    @Parameter(
+                            required = false,
+                            name = "groupId",
+                            description = "Deprectated.",
+                            deprecated = true,
+                            in = ParameterIn.QUERY
+                    )
+            }
     )
     @GetMapping("/services")
-    public ServicesListing getMyServices(@Parameter(hidden = true) Region region, @Parameter(hidden=true) Project project, @RequestParam(required = false) String groupId) throws Exception {
+    public ServicesListing getMyServices(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project, @RequestParam(required = false) String groupId) throws Exception {
         User user = userProvider.getUser(region);
         ServicesListing dto = new ServicesListing();
         List<CompletableFuture<ServicesListing>> futures = new ArrayList<>();
         if (region.getServices().getType().equals(Service.ServiceType.KUBERNETES)) {
-            futures.add(helmAppsService.getUserServices(region,project,user,groupId));
+            futures.add(helmAppsService.getUserServices(region, project, user, groupId));
         }
         for (var future : futures) {
             ServicesListing listing = future.get();
@@ -82,31 +82,31 @@ public class MyLabController {
     }
 
     @Operation(
-        summary = "Get the description of an installed service.",
-        description = "Get the description of an installed service in the namespace. With Kubernetes backend, an installed service can be seen as a Helm chart. Its unique identifier will be the release name on the namespace.",
-        parameters={
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "Generated project id.",
-                    example = "project-id-example"
-                )
-            ),
-            @Parameter(
-                name = "serviceId",
-                description = "Unique ID of the installed service in that namespace.",
-                required = true,
-                in = ParameterIn.QUERY
-            )
-        }
+            summary = "Get the description of an installed service.",
+            description = "Get the description of an installed service in the namespace. With Kubernetes backend, an installed service can be seen as a Helm chart. Its unique identifier will be the release name on the namespace.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "Generated project id.",
+                                    example = "project-id-example"
+                            )
+                    ),
+                    @Parameter(
+                            name = "serviceId",
+                            description = "Unique ID of the installed service in that namespace.",
+                            required = true,
+                            in = ParameterIn.QUERY
+                    )
+            }
     )
     @GetMapping("/app")
-    public @ResponseBody Service getApp(@Parameter(hidden = true) Region region,@Parameter(hidden=true) Project project, @RequestParam("serviceId") String serviceId) throws Exception {
+    public @ResponseBody Service getApp(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project, @RequestParam("serviceId") String serviceId) throws Exception {
         if (Service.ServiceType.KUBERNETES.equals(region.getServices().getType())) {
             return helmAppsService.getUserService(region, project, userProvider.getUser(region), serviceId);
         }
@@ -114,76 +114,76 @@ public class MyLabController {
     }
 
     @Operation(
-        summary = "Get the logs of a task in an installed service.",
-        description = "Get the logs of a task in an installed service. With Kubernetes backend, it can be seen as the logs of a pod in the service.",
-        parameters={
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "Generated project id.",
-                    example = "project-id-example"
-                )
-            ),
-            @Parameter(
-                name = "serviceId",
-                description = "Unique ID of the installed service in that namespace.",
-                required = true,
-                in = ParameterIn.QUERY
-            ),
-            @Parameter(
-                name = "taskId",
-                description = "Unique ID of the task from the installed service.",
-                required = true,
-                in = ParameterIn.QUERY
-            )
-        }
+            summary = "Get the logs of a task in an installed service.",
+            description = "Get the logs of a task in an installed service. With Kubernetes backend, it can be seen as the logs of a pod in the service.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "Generated project id.",
+                                    example = "project-id-example"
+                            )
+                    ),
+                    @Parameter(
+                            name = "serviceId",
+                            description = "Unique ID of the installed service in that namespace.",
+                            required = true,
+                            in = ParameterIn.QUERY
+                    ),
+                    @Parameter(
+                            name = "taskId",
+                            description = "Unique ID of the task from the installed service.",
+                            required = true,
+                            in = ParameterIn.QUERY
+                    )
+            }
     )
     @GetMapping("/app/logs")
-    public @ResponseBody String getLogs( @Parameter(hidden = true) Region region, @Parameter(hidden=true) Project project, @RequestParam("serviceId") String serviceId,
+    public @ResponseBody String getLogs(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project, @RequestParam("serviceId") String serviceId,
                                         @RequestParam("taskId") String taskId) {
         if (Service.ServiceType.KUBERNETES.equals(region.getServices().getType())) {
-            return helmAppsService.getLogs(region, project,userProvider.getUser(region),serviceId, taskId);
+            return helmAppsService.getLogs(region, project, userProvider.getUser(region), serviceId, taskId);
         }
         return null;
     }
 
     @Operation(
-        summary = "Delete an installed service(s) launched through Onyxia.",
-        description = "Delete an installed service launched through Onyxia on the namespace given the path, or delete *ALL* installed services on the namespace on bulk deletes. It will prioritize the bulk parameter.",
-        parameters={
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "Generated project id.",
-                    example = "project-id-example"
-                )
-            ),
-            @Parameter(
-                name = "path",
-                description = "Path to the installed service in that namespace.",
-                required = false,
-                in = ParameterIn.QUERY
-            ),
-            @Parameter(
-                name = "bulk",
-                description = "Wheather to delete all services in a namespace, if set to true, or to look at path.",
-                required = false,
-                in = ParameterIn.QUERY
-            )
-        }
+            summary = "Delete an installed service(s) launched through Onyxia.",
+            description = "Delete an installed service launched through Onyxia on the namespace given the path, or delete *ALL* installed services on the namespace on bulk deletes. It will prioritize the bulk parameter.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "Generated project id.",
+                                    example = "project-id-example"
+                            )
+                    ),
+                    @Parameter(
+                            name = "path",
+                            description = "Path to the installed service in that namespace.",
+                            required = false,
+                            in = ParameterIn.QUERY
+                    ),
+                    @Parameter(
+                            name = "bulk",
+                            description = "Wheather to delete all services in a namespace, if set to true, or to look at path.",
+                            required = false,
+                            in = ParameterIn.QUERY
+                    )
+            }
     )
     @DeleteMapping("/app")
-    public UninstallService destroyApp(@Parameter(hidden = true) Region region, @Parameter(hidden=true) Project project, @RequestParam(value = "path", required = false) String path,@RequestParam(value = "bulk", required = false) boolean bulk) throws Exception {
+    public UninstallService destroyApp(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project, @RequestParam(value = "path", required = false) String path, @RequestParam(value = "bulk", required = false) boolean bulk) throws Exception {
         if (Service.ServiceType.KUBERNETES.equals(region.getServices().getType())) {
             return helmAppsService.destroyService(region, project, userProvider.getUser(region), path, bulk);
         }
@@ -191,25 +191,25 @@ public class MyLabController {
     }
 
     @Operation(
-        summary = "Launch a service package through Onyxia.",
-        description = "Launch a service package through Onyxia in the namespace, given its catalog, package and configurations out of the available services in this Onyxia instance. More information of available catalogs and packages can be found in the public endpoints.",
-        parameters={
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "Generated project id.",
-                    example = "project-id-example"
-                )
-            )
-        }
+            summary = "Launch a service package through Onyxia.",
+            description = "Launch a service package through Onyxia in the namespace, given its catalog, package and configurations out of the available services in this Onyxia instance. More information of available catalogs and packages can be found in the public endpoints.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "Generated project id.",
+                                    example = "project-id-example"
+                            )
+                    )
+            }
     )
     @PutMapping("/app")
-    public Object publishService(@Parameter(hidden = true) Region region, @Parameter(hidden=true) Project project,@RequestBody CreateServiceDTO requestDTO)
+    public Object publishService(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project, @RequestBody CreateServiceDTO requestDTO)
             throws JsonProcessingException, IOException, Exception {
         return publishApps(region, project, requestDTO);
     }
@@ -225,9 +225,8 @@ public class MyLabController {
         User user = userProvider.getUser(region);
         Map<String, Object> fusion = new HashMap<>();
         fusion.putAll((Map<String, Object>) requestDTO.getOptions());
-        return helmAppsService.installApp(region,project,requestDTO, catalogId, pkg, user, fusion);
+        return helmAppsService.installApp(region, project, requestDTO, catalogId, pkg, user, fusion);
     }
-
 
 
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/QuotaController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/QuotaController.java
@@ -8,12 +8,12 @@ import fr.insee.onyxia.model.service.quota.Quota;
 import fr.insee.onyxia.model.service.quota.QuotaUsage;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceQuota;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Tag(name = "My lab", description = "My services")
-@RequestMapping(value={"/api/my-lab/quota", "/my-lab/quota"})
+@RequestMapping("/my-lab/quota")
 @RestController
 @SecurityRequirement(name = "auth")
 public class QuotaController {
@@ -34,21 +34,21 @@ public class QuotaController {
     private UserProvider userProvider;
 
     @Operation(
-        summary = "Obtain the quota for a namespace.",
-        description = "Obtain both the quota limit for a namespace and the current quota usage, if quota limits are enabled on Onyxia.",
-        parameters = {
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "generated project id"
-                )
-            )
-        }
+            summary = "Obtain the quota for a namespace.",
+            description = "Obtain both the quota limit for a namespace and the current quota usage, if quota limits are enabled on Onyxia.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "generated project id"
+                            )
+                    )
+            }
     )
     @GetMapping
     public QuotaUsage getQuota(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project) {
@@ -59,7 +59,7 @@ public class QuotaController {
         }
 
         QuotaUsage quotaUsage = new QuotaUsage();
-        Quota spec  = new Quota();
+        Quota spec = new Quota();
         Quota usage = new Quota();
         mapKubQuotaToQuota(resourceQuota.getStatus().getHard(), spec);
         mapKubQuotaToQuota(resourceQuota.getStatus().getUsed(), usage);
@@ -70,48 +70,48 @@ public class QuotaController {
     }
 
     @Operation(
-        summary = "Change the quota for a namespace.",
-        description = "Change the quota for a namespace if the quota changing option is enabled.",
-        parameters = {
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "generated project id"
-                )
-            )
-        }
+            summary = "Change the quota for a namespace.",
+            description = "Change the quota for a namespace if the quota changing option is enabled.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "generated project id"
+                            )
+                    )
+            }
     )
     @PostMapping
-    public void applyQuota(@Parameter(hidden = true) Region region, @Parameter(hidden=true) Project project, @RequestBody Quota quota) throws IllegalAccessException {
+    public void applyQuota(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project, @RequestBody Quota quota) throws IllegalAccessException {
         checkQuotaIsEnabled(region);
         checkQuotaModificationIsAllowed(region);
         kubernetesService.applyQuota(region, project, userProvider.getUser(region), quota);
     }
 
     @Operation(
-        summary = "Reset the quota for a namespace to the default value.",
-        description = "Reset the quota for a namespace to the default value if the quota changing option is enabled.",
-        parameters = {
-            @Parameter(
-                required = false,
-                name = "ONYXIA-PROJECT",
-                description = "Project associated with the namespace, defaults to user project.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-PROJECT",
-                    type = "string",
-                    description = "generated project id"
-                )
-            )
-        }
+            summary = "Reset the quota for a namespace to the default value.",
+            description = "Reset the quota for a namespace to the default value if the quota changing option is enabled.",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-PROJECT",
+                            description = "Project associated with the namespace, defaults to user project.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-PROJECT",
+                                    type = "string",
+                                    description = "generated project id"
+                            )
+                    )
+            }
     )
     @PostMapping("/reset")
-    public void resetQuota(@Parameter(hidden = true) Region region, @Parameter(hidden=true) Project project) {
+    public void resetQuota(@Parameter(hidden = true) Region region, @Parameter(hidden = true) Project project) {
         checkQuotaIsEnabled(region);
         checkQuotaModificationIsAllowed(region);
         if (!region.getServices().getQuotas().isAllowUserModification()) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Onboarding", description = "Onboarding related services")
-@RequestMapping(value={"/api/onboarding", "/onboarding"})
+@RequestMapping("/onboarding")
 @RestController
 @SecurityRequirement(name = "auth")
 public class OnboardingController {
@@ -29,20 +29,20 @@ public class OnboardingController {
     private UserProvider userProvider;
 
     @Operation(
-        summary = "Init a namespace for a user or a group.",
-        description = "create or replace the namespace of the user or the namespace of a group if the user is in the requested group and the according rbac policies. with the group prefix / user prefix of the region",
-        parameters = {
-            @Parameter(
-                required = false,
-                name = "ONYXIA-REGION",
-                description = "The region used by the user, if not provided default to the first region configured.",
-                in = ParameterIn.HEADER,
-                schema = @Schema(
-                    name = "ONYXIA-REGION",
-                    type = "string"
-                )
-            )
-        }
+            summary = "Init a namespace for a user or a group.",
+            description = "create or replace the namespace of the user or the namespace of a group if the user is in the requested group and the according rbac policies. with the group prefix / user prefix of the region",
+            parameters = {
+                    @Parameter(
+                            required = false,
+                            name = "ONYXIA-REGION",
+                            description = "The region used by the user, if not provided default to the first region configured.",
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(
+                                    name = "ONYXIA-REGION",
+                                    type = "string"
+                            )
+                    )
+            }
     )
     @PostMapping
     public void onboard(@Parameter(hidden = true) Region region, @RequestBody OnboardingRequest request) {
@@ -51,8 +51,7 @@ public class OnboardingController {
         if (request.getGroup() != null) {
             owner.setId(request.getGroup());
             owner.setType(KubernetesService.Owner.OwnerType.GROUP);
-        }
-        else {
+        } else {
             owner.setId(userProvider.getUser(region).getIdep());
             owner.setType(KubernetesService.Owner.OwnerType.USER);
         }
@@ -66,7 +65,7 @@ public class OnboardingController {
         }
     }
 
-    @Schema(description="Specification on which namespace to create. If group is provided, create a group namespace, otherwise create the user namespace.")
+    @Schema(description = "Specification on which namespace to create. If group is provided, create a group namespace, otherwise create the user namespace.")
     public static class OnboardingRequest {
 
         @Schema(required = false)

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/s3/S3Controller.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/s3/S3Controller.java
@@ -14,11 +14,12 @@ import software.amazon.awssdk.services.s3.model.CORSConfiguration;
 import software.amazon.awssdk.services.s3.model.CORSRule;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.PutBucketCorsRequest;
+
 import java.util.ArrayList;
 import java.util.List;
 
 @Tag(name = "S3", description = "S3 related services")
-@RequestMapping(value={"/api/s3", "/s3"})
+@RequestMapping("/s3")
 @RestController
 @SecurityRequirement(name = "auth")
 public class S3Controller {
@@ -27,7 +28,7 @@ public class S3Controller {
     @PostMapping
     public void createBucket(String awsRegion, String accessKey, String secretKey, String sessionToken, String bucketName) {
         software.amazon.awssdk.regions.Region region = software.amazon.awssdk.regions.Region.of(awsRegion);
-        AwsCredentials creds = AwsSessionCredentials.create(accessKey,secretKey,sessionToken);
+        AwsCredentials creds = AwsSessionCredentials.create(accessKey, secretKey, sessionToken);
         try (S3Client s3 = S3Client.builder()
                 .region(region)
                 .credentialsProvider(StaticCredentialsProvider.create(creds))
@@ -36,7 +37,7 @@ public class S3Controller {
             CreateBucketRequest req = CreateBucketRequest.builder().bucket(bucketName).build();
             SdkHttpResponse response = s3.createBucket(req).sdkHttpResponse();
             if (!response.isSuccessful()) {
-                throw new RuntimeException("Bucket creation failed "+response.statusText());
+                throw new RuntimeException("Bucket creation failed " + response.statusText());
             }
             // Apply CORS
             List<String> allowedMethods = new ArrayList<>();
@@ -49,7 +50,7 @@ public class S3Controller {
             CORSConfiguration corsConfig = CORSConfiguration.builder().corsRules(rule).build();
             SdkHttpResponse corsResponse = s3.putBucketCors(PutBucketCorsRequest.builder().bucket(bucketName).corsConfiguration(corsConfig).build()).sdkHttpResponse();
             if (!corsResponse.isSuccessful()) {
-                throw new RuntimeException("Bucket creation failed "+response.statusText());
+                throw new RuntimeException("Bucket creation failed " + response.statusText());
             }
         }
     }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/user/UserController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/user/UserController.java
@@ -11,18 +11,18 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "User",description = "Personal data")
-@RequestMapping(value={"/api/user", "/user"})
+@Tag(name = "User", description = "Personal data")
+@RequestMapping("/user")
 @RestController
-@SecurityRequirement(name="auth")
+@SecurityRequirement(name = "auth")
 public class UserController {
 
-   @Autowired
-   private OnyxiaUserProvider userProvider;
+    @Autowired
+    private OnyxiaUserProvider userProvider;
 
-   @GetMapping("/info")
-   public OnyxiaUser userInfo(@Parameter(hidden = true) Region region) {
-      return userProvider.getUser(region);
-   }
+    @GetMapping("/info")
+    public OnyxiaUser userInfo(@Parameter(hidden = true) Region region) {
+        return userProvider.getUser(region);
+    }
 
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/CatalogController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/CatalogController.java
@@ -7,14 +7,14 @@ import fr.insee.onyxia.api.services.CatalogService;
 import fr.insee.onyxia.model.catalog.Config.Property;
 import fr.insee.onyxia.model.catalog.Config.Property.XForm;
 import fr.insee.onyxia.model.catalog.Config.Property.XOnyxia;
-import fr.insee.onyxia.model.helm.Chart;
 import fr.insee.onyxia.model.catalog.Pkg;
+import fr.insee.onyxia.model.helm.Chart;
 import fr.insee.onyxia.model.region.Region;
 import fr.insee.onyxia.model.service.Service;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Tag(name = "Public")
-@RequestMapping(value={"/api/public/catalog", "/public/catalog", "/api/public/catalogs", "/public/catalogs"})
+@RequestMapping(value = {"/public/catalog", "/public/catalogs"})
 @RestController
 public class CatalogController {
 
@@ -35,8 +35,8 @@ public class CatalogController {
    private CatalogService catalogService;
 
    @Operation(
-      summary = "List available catalogs and packages for installing.",
-      description = "List available catalogs and packages for installing in the first Region configuration of this Onyxia API."
+           summary = "List available catalogs and packages for installing.",
+           description = "List available catalogs and packages for installing in the first Region configuration of this Onyxia API."
    )
    @GetMapping
    public Catalogs getCatalogs(@Parameter(hidden = true) Region region) {
@@ -46,16 +46,16 @@ public class CatalogController {
    }
 
    @Operation(
-      summary = "List available packages for installing given a catalog.",
-      description = "List available packages for installing given a catalog with detailed information on the packages including: descriptions, sources, and configuration options.",
-      parameters = {
-         @Parameter(
-            required = true,
-            name = "catalogId",
-            description = "Unique ID of the enabled catalog for this Onyxia API.",
-            in = ParameterIn.PATH
-         )
-      }
+           summary = "List available packages for installing given a catalog.",
+           description = "List available packages for installing given a catalog with detailed information on the packages including: descriptions, sources, and configuration options.",
+           parameters = {
+                   @Parameter(
+                           required = true,
+                           name = "catalogId",
+                           description = "Unique ID of the enabled catalog for this Onyxia API.",
+                           in = ParameterIn.PATH
+                   )
+           }
    )
    @GetMapping("{catalogId}")
    public CatalogWrapper getCatalogById(@PathVariable String catalogId) {
@@ -67,22 +67,22 @@ public class CatalogController {
    }
 
    @Operation(
-      summary = "Get a service package information from a specific catalog.",
-      description = "Get a service package information from a specific catalog, with detailed information on the package including: descriptions, sources, and configuration options.",
-      parameters = {
-         @Parameter(
-            required = true,
-            name = "catalogId",
-            description = "Unique ID of the enabled catalog for this Onyxia API.",
-            in = ParameterIn.PATH
-         ),
-         @Parameter(
-            required = true,
-            name = "packageName",
-            description = "Unique name of the package from the selected catalog.",
-            in = ParameterIn.PATH
-         )
-      }
+           summary = "Get a service package information from a specific catalog.",
+           description = "Get a service package information from a specific catalog, with detailed information on the package including: descriptions, sources, and configuration options.",
+           parameters = {
+                   @Parameter(
+                           required = true,
+                           name = "catalogId",
+                           description = "Unique ID of the enabled catalog for this Onyxia API.",
+                           in = ParameterIn.PATH
+                   ),
+                   @Parameter(
+                           required = true,
+                           name = "packageName",
+                           description = "Unique name of the package from the selected catalog.",
+                           in = ParameterIn.PATH
+                   )
+           }
    )
    @GetMapping("{catalogId}/{packageName}")
    public Pkg getPackage(@PathVariable String catalogId, @PathVariable String packageName) {
@@ -95,28 +95,28 @@ public class CatalogController {
    }
 
    @Operation(
-      summary = "Get a helm chart from a specific catalog by version.",
-      description = "Get a helm chart from a specific catalog by version, with detailed information on the package including: descriptions, sources, and configuration options.",
-      parameters = {
-         @Parameter(
-            required = true,
-            name = "catalogId",
-            description = "Unique ID of the enabled catalog for this Onyxia API.",
-            in = ParameterIn.PATH
-         ),
-         @Parameter(
-            required = true,
-            name = "chartName",
-            description = "Unique name of the chart from the selected catalog.",
-            in = ParameterIn.PATH
-         ),
-         @Parameter(
-            required = true,
-            name = "version",
-            description = "Version of the chart",
-            in = ParameterIn.PATH
-         )
-      }
+           summary = "Get a helm chart from a specific catalog by version.",
+           description = "Get a helm chart from a specific catalog by version, with detailed information on the package including: descriptions, sources, and configuration options.",
+           parameters = {
+                   @Parameter(
+                           required = true,
+                           name = "catalogId",
+                           description = "Unique ID of the enabled catalog for this Onyxia API.",
+                           in = ParameterIn.PATH
+                   ),
+                   @Parameter(
+                           required = true,
+                           name = "chartName",
+                           description = "Unique name of the chart from the selected catalog.",
+                           in = ParameterIn.PATH
+                   ),
+                   @Parameter(
+                           required = true,
+                           name = "version",
+                           description = "Version of the chart",
+                           in = ParameterIn.PATH
+                   )
+           }
    )
    @GetMapping("{catalogId}/charts/{chartName}/versions/{version}")
    public Chart getChartByVersion(@PathVariable String catalogId, @PathVariable String chartName, @PathVariable String version) {
@@ -126,22 +126,22 @@ public class CatalogController {
    }
 
    @Operation(
-      summary = "Get all versions of a chart from a specific catalog.",
-      description = "Get all versions of a chart from a specific catalog, with detailed information on the package including: descriptions, sources, and configuration options.",
-      parameters = {
-         @Parameter(
-            required = true,
-            name = "catalogId",
-            description = "Unique ID of the enabled catalog for this Onyxia API.",
-            in = ParameterIn.PATH
-         ),
-         @Parameter(
-            required = true,
-            name = "chartName",
-            description = "Unique name of the chart from the selected catalog.",
-            in = ParameterIn.PATH
-         )
-      }
+           summary = "Get all versions of a chart from a specific catalog.",
+           description = "Get all versions of a chart from a specific catalog, with detailed information on the package including: descriptions, sources, and configuration options.",
+           parameters = {
+                   @Parameter(
+                           required = true,
+                           name = "catalogId",
+                           description = "Unique ID of the enabled catalog for this Onyxia API.",
+                           in = ParameterIn.PATH
+                   ),
+                   @Parameter(
+                           required = true,
+                           name = "chartName",
+                           description = "Unique name of the chart from the selected catalog.",
+                           in = ParameterIn.PATH
+                   )
+           }
    )
    @GetMapping("{catalogId}/charts/{chartName}")
    public List<Chart> getCharts(@PathVariable String catalogId, @PathVariable String chartName) {
@@ -168,7 +168,7 @@ public class CatalogController {
       property.setDescription("Onyxia specific configuration");
       property.setType("object");
       property.setProperties(new HashMap<>());
-      Map<String,Property> onyxiaProperties = new HashMap<>();
+      Map<String, Property> onyxiaProperties = new HashMap<>();
       Property customName = new Property();
       customName.setType("string");
       customName.setDescription("Service custom name");
@@ -180,7 +180,7 @@ public class CatalogController {
       userDefinedValues.setDescription("Values defined by the end user");
       userDefinedValues.setDefaut("");
       userDefinedValues.setTitle("User defined values");
-      onyxiaProperties.put("userDefinedValues", userDefinedValues);      
+      onyxiaProperties.put("userDefinedValues", userDefinedValues);
       Property owner = new Property();
       owner.setType("string");
       owner.setDescription("Owner of the chart");
@@ -205,7 +205,7 @@ public class CatalogController {
 
       property.setProperties(onyxiaProperties);
 
-      properties.put("onyxia",property);
+      properties.put("onyxia", property);
    }
 
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/ConfigurationController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/ConfigurationController.java
@@ -2,10 +2,9 @@ package fr.insee.onyxia.api.controller.pub;
 
 import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
 import fr.insee.onyxia.model.region.Region;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,8 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@Tag(name="Public", description = "Information endpoints")
-@RequestMapping(value={"/api/public", "/public"})
+@Tag(name = "Public", description = "Information endpoints")
+@RequestMapping("/public")
 public class ConfigurationController {
 
     @Autowired(required = false)
@@ -26,8 +25,8 @@ public class ConfigurationController {
     private RegionsConfiguration regionsConfiguration;
 
     @Operation(
-        summary = "Get this Onyxia API full configuration description.",
-        description = "Get Onyxia API build info and associated list of Regions, the configuration blocks of Onyxia."
+            summary = "Get this Onyxia API full configuration description.",
+            description = "Get Onyxia API build info and associated list of Regions, the configuration blocks of Onyxia."
     )
     @GetMapping("/configuration")
     public AppInfo configuration() {
@@ -42,28 +41,27 @@ public class ConfigurationController {
         return appInfo;
     }
 
-	@Schema(description = "Cloudshell data and health")
+    @Schema(description = "Cloudshell data and health")
     public class AppInfo {
 
 
         private BuildInfo build;
         private List<Region> regions;
 
+        public BuildInfo getBuild() {
+            return build;
+        }
 
         public void setBuild(BuildInfo build) {
             this.build = build;
         }
 
-        public void setRegions(List<Region> regions) {
-            this.regions = regions;
-        }
-
-        public BuildInfo getBuild() {
-            return build;
-        }
-
         public List<Region> getRegions() {
             return regionsConfiguration.getResolvedRegions();
+        }
+
+        public void setRegions(List<Region> regions) {
+            this.regions = regions;
         }
     }
 
@@ -74,20 +72,20 @@ public class ConfigurationController {
         @Schema(description = "")
         private long timestamp;
 
-        public void setTimestamp(long timestamp) {
-            this.timestamp = timestamp;
-        }
-
-        public void setVersion(String version) {
-            this.version = version;
-        }
-
         public long getTimestamp() {
             return timestamp;
         }
 
+        public void setTimestamp(long timestamp) {
+            this.timestamp = timestamp;
+        }
+
         public String getVersion() {
             return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
         }
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/IPController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/IPController.java
@@ -1,10 +1,9 @@
 package fr.insee.onyxia.api.controller.pub;
 
 import fr.insee.onyxia.api.services.utils.HttpRequestUtils;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
-
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,15 +13,15 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 @RestController
 @Tag(name = "Public")
-@RequestMapping(value={"/api/public", "/public"})
+@RequestMapping("/public")
 public class IPController {
 
     @Autowired
     HttpRequestUtils httpRequestUtils;
 
     @Operation(
-        summary = "Get your public IP address.",
-        description = "Get the IP addresses of the service caller if it exist on the forwarding headers, otherwise it returns the remote address of the servlet request."
+            summary = "Get your public IP address.",
+            description = "Get the IP addresses of the service caller if it exist on the forwarding headers, otherwise it returns the remote address of the servlet request."
     )
     @GetMapping("/ip")
     public IP getIP() {
@@ -31,17 +30,17 @@ public class IPController {
         return ip;
     }
 
-    public void setHttpRequestUtils(HttpRequestUtils httpRequestUtils) {
-        this.httpRequestUtils = httpRequestUtils;
-    }
-
     public HttpRequestUtils getHttpRequestUtils() {
         return httpRequestUtils;
     }
 
-	@Schema(description = "")
+    public void setHttpRequestUtils(HttpRequestUtils httpRequestUtils) {
+        this.httpRequestUtils = httpRequestUtils;
+    }
+
+    @Schema(description = "")
     public static class IP {
-	    @Schema(description = "")
+        @Schema(description = "")
         private String ip;
 
         public String getIp() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/RegionsController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/RegionsController.java
@@ -2,8 +2,8 @@ package fr.insee.onyxia.api.controller.pub;
 
 import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
 import fr.insee.onyxia.model.region.Region;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @Tag(name = "Public")
-@RequestMapping(value={"/api/public/regions", "/public/regions"})
+@RequestMapping("/public/regions")
 @RestController
 public class RegionsController {
 
@@ -20,11 +20,11 @@ public class RegionsController {
     private RegionsConfiguration regionsConfiguration;
 
     @Operation(
-        summary = "Get Onyxia API regions configurations.",
-        description = "Get Onyxia API associated list of Regions, the configuration blocks of Onyxia. Recall that the first region will be used as default for /my-lab/ requests."
+            summary = "Get Onyxia API regions configurations.",
+            description = "Get Onyxia API associated list of Regions, the configuration blocks of Onyxia. Recall that the first region will be used as default for /my-lab/ requests."
     )
     @GetMapping
-    public List<Region>  getRegions() {
+    public List<Region> getRegions() {
         return regionsConfiguration.getResolvedRegions();
     }
 }

--- a/onyxia-api/src/main/kotlin/fr/insee/onyxia/api/controller/pub/HealthcheckController.kt
+++ b/onyxia-api/src/main/kotlin/fr/insee/onyxia/api/controller/pub/HealthcheckController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @Tag(name = "Public")
-@RequestMapping(value = ["/api/public", "/public"])
+@RequestMapping("/public")
 class HealthcheckController {
 
     @GetMapping("/healthcheck")


### PR DESCRIPTION
The logic of adding `/api` to the URL has been moved out of the scope of the `onyxia-api` and is now handled outside of it e.g in helm : https://github.com/InseeFrLab/helm-charts/blob/master/charts/onyxia/values.yaml#L81  
So now we can cleanup routes for better readability and maintainability