### PR TITLE
Compile with java 17

### DIFF
--- a/helm-wrapper/pom.xml
+++ b/helm-wrapper/pom.xml
@@ -17,7 +17,8 @@
     <description>Simple wrapper for Helm (https://helm.sh)</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
+        <fabric8io.version>6.2.0</fabric8io.version>
     </properties>
 
     <distributionManagement>
@@ -67,7 +68,7 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>6.2.0</version>
+            <version>${fabric8io.version}</version>
         </dependency>
 
         <dependency>

--- a/onyxia-api/pom.xml
+++ b/onyxia-api/pom.xml
@@ -127,7 +127,7 @@
     </dependencies>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <kotlin.version>1.7.0</kotlin.version>
     </properties>
 

--- a/onyxia-model/pom.xml
+++ b/onyxia-model/pom.xml
@@ -11,8 +11,8 @@
         <version>2.7.5</version>
     </parent>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,23 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>innovation.insee</groupId>
-  <artifactId>onyxia</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
-  <packaging>pom</packaging>
-  <modules>
-    <module>onyxia-model</module>
-    <module>onyxia-api</module>
-    <module>helm-wrapper</module>
-  </modules>
-  <distributionManagement>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>innovation.insee</groupId>
+    <artifactId>onyxia</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>onyxia-model</module>
+        <module>onyxia-api</module>
+        <module>helm-wrapper</module>
+    </modules>
+    <distributionManagement>
 
-  </distributionManagement>
-  <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-  </properties>
-
+    </distributionManagement>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
 
 
 </project>


### PR DESCRIPTION
Java 17 is the latest LTS version of Java, we should use it as the compile version (we currently already use JDK 17 to build in CI but in a 11-compatible way)