### PR TITLE
Add CA certificates support for Helm registry

### DIFF
--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
@@ -34,11 +34,16 @@ public class HelmInstallService {
             boolean dryRun,
             File values,
             Map<String, String> env,
-            final boolean skipTlsVerify)
+            final boolean skipTlsVerify,
+            String caFile)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
         String command = "helm upgrade --install ";
         if (skipTlsVerify) {
             command = command.concat("--insecure-skip-tls-verify ");
+        } else if (caFile != null) {
+            command =
+                    command.concat(
+                            "--ca-file " + System.getenv("CACERTS_DIR") + "/" + caFile + " ");
         }
         if (name != null) {
             command = command.concat(name + " ");

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
@@ -33,9 +33,13 @@ public class HelmInstallService {
             String version,
             boolean dryRun,
             File values,
-            Map<String, String> env)
+            Map<String, String> env,
+            final boolean skipTlsVerify)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
         String command = "helm upgrade --install ";
+        if (skipTlsVerify) {
+            command = command.concat("--insecure-skip-tls-verify ");
+        }
         if (name != null) {
             command = command.concat(name + " ");
         } else {

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmRepoService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmRepoService.java
@@ -24,11 +24,19 @@ public class HelmRepoService {
         return repo;
     }
 
-    public String addHelmRepo(final String url, final String nomRepo, final boolean skipTlsVerify)
+    public String addHelmRepo(
+            final String url,
+            final String nomRepo,
+            final boolean skipTlsVerify,
+            final String caFile)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
         String command = "helm repo add ";
         if (skipTlsVerify) {
             command = command.concat("--insecure-skip-tls-verify ");
+        } else if (caFile != null) {
+            command =
+                    command.concat(
+                            "--ca-file " + System.getenv("CACERTS_DIR") + "/" + caFile + " ");
         }
         command = command.concat(nomRepo + " " + url);
         return Command.execute(command).getOutput().getString();

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmRepoService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmRepoService.java
@@ -24,9 +24,14 @@ public class HelmRepoService {
         return repo;
     }
 
-    public String addHelmRepo(final String url, final String nomRepo)
+    public String addHelmRepo(final String url, final String nomRepo, final boolean skipTlsVerify)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        return Command.execute("helm repo add " + nomRepo + " " + url).getOutput().getString();
+        String command = "helm repo add ";
+        if (skipTlsVerify) {
+            command = command.concat("--insecure-skip-tls-verify ");
+        }
+        command = command.concat(nomRepo + " " + url);
+        return Command.execute(command).getOutput().getString();
     }
 
     public void repoUpdate() throws InterruptedException, TimeoutException, IOException {

--- a/helm-wrapper/src/test/java/io/github/inseefrlab/helmwrapper/RepoServiceTest.java
+++ b/helm-wrapper/src/test/java/io/github/inseefrlab/helmwrapper/RepoServiceTest.java
@@ -17,7 +17,8 @@ public class RepoServiceTest {
     @Test
     public void should() throws Exception {
         HelmRepoService repoService = new HelmRepoService();
-        helmRepoService.addHelmRepo("https://inseefrlab.github.io/helm-charts", "inseefrlab");
+        helmRepoService.addHelmRepo(
+                "https://inseefrlab.github.io/helm-charts", "inseefrlab", false);
         HelmRepo[] repos = helmRepoService.getHelmRepo();
         Assertions.assertEquals(1, repos.length);
     }

--- a/helm-wrapper/src/test/java/io/github/inseefrlab/helmwrapper/RepoServiceTest.java
+++ b/helm-wrapper/src/test/java/io/github/inseefrlab/helmwrapper/RepoServiceTest.java
@@ -18,7 +18,7 @@ public class RepoServiceTest {
     public void should() throws Exception {
         HelmRepoService repoService = new HelmRepoService();
         helmRepoService.addHelmRepo(
-                "https://inseefrlab.github.io/helm-charts", "inseefrlab", false);
+                "https://inseefrlab.github.io/helm-charts", "inseefrlab", false, null);
         HelmRepo[] repos = helmRepoService.getHelmRepo();
         Assertions.assertEquals(1, repos.length);
     }

--- a/onyxia-api/Dockerfile
+++ b/onyxia-api/Dockerfile
@@ -4,6 +4,10 @@ RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | D
 COPY target/*.jar app.jar
 RUN groupadd --gid 101 --system onyxia && \
     useradd --system --uid 101 --create-home --home-dir /var/cache/onyxia --shell /sbin/nologin --gid onyxia --comment onyxia onyxia
+# Allow adding CA certificates
+ENV CACERTS_DIR="/usr/local/share/ca-certificates"
+RUN chown onyxia $JAVA_HOME/lib/security/cacerts
+COPY entrypoint.sh entrypoint.sh
 # Equivalent to 'USER onyxia', see: https://github.com/InseeFrLab/onyxia-api/pull/116
 USER 101
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/onyxia-api/entrypoint.sh
+++ b/onyxia-api/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Import CA certificates to Java keystore
+for file in $CACERTS_DIR/*
+do
+  echo "Adding $file to keystore"
+  keytool -import -cacerts -trustcacerts -noprompt -storepass changeit -alias $(basename $file) -file $file
+done
+
+# Run application
+java -jar /app.jar

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
@@ -49,6 +49,9 @@ public class CatalogWrapper {
     @Schema(description = "Skip tls certificate checks for the repository")
     private boolean skipTlsVerify;
 
+    @Schema(description = "Verify certificates of HTTPS-enabled servers using this CA bundle")
+    private String caFile;
+
     /**
      * @return the type
      */
@@ -160,5 +163,13 @@ public class CatalogWrapper {
 
     public void setSkipTlsVerify(boolean skipTlsVerify) {
         this.skipTlsVerify = skipTlsVerify;
+    }
+
+    public String getCaFile() {
+        return caFile;
+    }
+
+    public void setCaFile(String caFile) {
+        this.caFile = caFile;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
@@ -46,6 +46,9 @@ public class CatalogWrapper {
     @Schema(description = "names of declarative important charts of the catalog")
     private List<String> highlightedCharts = new ArrayList<>();
 
+    @Schema(description = "Skip tls certificate checks for the repository")
+    private boolean skipTlsVerify;
+
     /**
      * @return the type
      */
@@ -149,5 +152,13 @@ public class CatalogWrapper {
 
     public void setHighlightedCharts(List<String> highlightedCharts) {
         this.highlightedCharts = highlightedCharts;
+    }
+
+    public boolean getSkipTlsVerify() {
+        return skipTlsVerify;
+    }
+
+    public void setSkipTlsVerify(boolean skipTlsVerify) {
+        this.skipTlsVerify = skipTlsVerify;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -235,10 +235,11 @@ public class MyLabController {
         }
         CatalogWrapper catalog = catalogService.getCatalogById(catalogId);
         Pkg pkg = catalog.getCatalog().getPackageByName(requestDTO.getPackageName());
+        boolean skipTlsVerify = catalog.getSkipTlsVerify();
         User user = userProvider.getUser(region);
         Map<String, Object> fusion = new HashMap<>();
         fusion.putAll((Map<String, Object>) requestDTO.getOptions());
         return helmAppsService.installApp(
-                region, project, requestDTO, catalogId, pkg, user, fusion);
+                region, project, requestDTO, catalogId, pkg, user, fusion, skipTlsVerify);
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -236,10 +236,11 @@ public class MyLabController {
         CatalogWrapper catalog = catalogService.getCatalogById(catalogId);
         Pkg pkg = catalog.getCatalog().getPackageByName(requestDTO.getPackageName());
         boolean skipTlsVerify = catalog.getSkipTlsVerify();
+        String caFile = catalog.getCaFile();
         User user = userProvider.getUser(region);
         Map<String, Object> fusion = new HashMap<>();
         fusion.putAll((Map<String, Object>) requestDTO.getOptions());
         return helmAppsService.installApp(
-                region, project, requestDTO, catalogId, pkg, user, fusion, skipTlsVerify);
+                region, project, requestDTO, catalogId, pkg, user, fusion, skipTlsVerify, caFile);
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
@@ -35,7 +35,10 @@ public class CatalogRefresher implements ApplicationRunner {
                             try {
                                 logger.info(
                                         helmRepoService.addHelmRepo(
-                                                c.getLocation(), c.getId(), c.getSkipTlsVerify()));
+                                                c.getLocation(),
+                                                c.getId(),
+                                                c.getSkipTlsVerify(),
+                                                c.getCaFile()));
                                 catalogLoader.updateCatalog(c);
                             } catch (Exception e) {
                                 e.printStackTrace();

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
@@ -34,7 +34,8 @@ public class CatalogRefresher implements ApplicationRunner {
                         c -> {
                             try {
                                 logger.info(
-                                        helmRepoService.addHelmRepo(c.getLocation(), c.getId()));
+                                        helmRepoService.addHelmRepo(
+                                                c.getLocation(), c.getId(), c.getSkipTlsVerify()));
                                 catalogLoader.updateCatalog(c);
                             } catch (Exception e) {
                                 e.printStackTrace();

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
@@ -33,7 +33,8 @@ public interface AppsService {
             Pkg pkg,
             User user,
             Map<String, Object> fusion,
-            final boolean skipTlsVerify)
+            final boolean skipTlsVerify,
+            final String caFile)
             throws Exception;
 
     Service getUserService(Region region, Project project, User user, String serviceId)

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
@@ -32,7 +32,8 @@ public interface AppsService {
             String catalogId,
             Pkg pkg,
             User user,
-            Map<String, Object> fusion)
+            Map<String, Object> fusion,
+            final boolean skipTlsVerify)
             throws Exception;
 
     Service getUserService(Region region, Project project, User user, String serviceId)

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -90,7 +90,8 @@ public class HelmAppsService implements AppsService {
             String catalogId,
             Pkg pkg,
             User user,
-            Map<String, Object> fusion)
+            Map<String, Object> fusion,
+            final boolean skipTlsVerify)
             throws IOException, TimeoutException, InterruptedException {
 
         PublishContext context = new PublishContext();
@@ -172,7 +173,8 @@ public class HelmAppsService implements AppsService {
                                 requestDTO.getPackageVersion(),
                                 requestDTO.isDryRun(),
                                 values,
-                                null);
+                                null,
+                                skipTlsVerify);
         values.delete();
         return List.of(res.getManifest());
     }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -91,7 +91,8 @@ public class HelmAppsService implements AppsService {
             Pkg pkg,
             User user,
             Map<String, Object> fusion,
-            final boolean skipTlsVerify)
+            final boolean skipTlsVerify,
+            final String caFile)
             throws IOException, TimeoutException, InterruptedException {
 
         PublishContext context = new PublishContext();
@@ -174,7 +175,8 @@ public class HelmAppsService implements AppsService {
                                 requestDTO.isDryRun(),
                                 values,
                                 null,
-                                skipTlsVerify);
+                                skipTlsVerify,
+                                caFile);
         values.delete();
         return List.of(res.getManifest());
     }

--- a/onyxia-api/src/main/resources/catalogs.json
+++ b/onyxia-api/src/main/resources/catalogs.json
@@ -8,7 +8,8 @@
       "location": "https://inseefrlab.github.io/helm-charts-interactive-services",
       "status": "PROD",
       "highlightedCharts": ["jupyter-python", "rstudio", "vscode-python"],
-      "type": "helm"
+      "type": "helm",
+      "skipTlsVerify": false
     },
     {
       "id": "databases",
@@ -18,7 +19,8 @@
       "location": "https://inseefrlab.github.io/helm-charts-databases",
       "status": "PROD",
       "highlightedCharts": ["postgresql", "elastic"],
-      "type": "helm"
+      "type": "helm",
+      "skipTlsVerify": false
     },
     {
       "id": "automation",
@@ -28,7 +30,8 @@
       "location": "https://inseefrlab.github.io/helm-charts-automation",
       "status": "PROD",
       "highlightedCharts": ["argo-cd", "argo-workflows", "mlflow"],
-      "type": "helm"
+      "type": "helm",
+      "skipTlsVerify": false
     }
   ]
 }

--- a/onyxia-api/src/main/resources/catalogs.json
+++ b/onyxia-api/src/main/resources/catalogs.json
@@ -9,7 +9,8 @@
       "status": "PROD",
       "highlightedCharts": ["jupyter-python", "rstudio", "vscode-python"],
       "type": "helm",
-      "skipTlsVerify": false
+      "skipTlsVerify": false,
+      "caFile": null
     },
     {
       "id": "databases",
@@ -20,7 +21,8 @@
       "status": "PROD",
       "highlightedCharts": ["postgresql", "elastic"],
       "type": "helm",
-      "skipTlsVerify": false
+      "skipTlsVerify": false,
+      "caFile": null
     },
     {
       "id": "automation",
@@ -31,7 +33,8 @@
       "status": "PROD",
       "highlightedCharts": ["argo-cd", "argo-workflows", "mlflow"],
       "type": "helm",
-      "skipTlsVerify": false
+      "skipTlsVerify": false,
+      "caFile": null
     }
   ]
 }


### PR DESCRIPTION
Fixes #188

It brings CA certificates support for Helm registry.

## Solution

Onyxia API now uses `CACERTS_DIR` environment variable which defines the location of CA certificates which are imported into Java keystore when `onyxia-api` is run. When setting a custom location, it must have read permissions for `onyxia` user or `onyxia` group. Default value is `/usr/local/share/ca-certificates`.

2 new options of the `catalogs` configuration of the chart values:

- `caFile` (string) - the name of the CA file located in a directory configured with the`CACERTS_DIR` environment variable . It is ignored if `skipTlsVerify` is `true`.
- `skipTlsVerify` (boolean) - if `true`, helm CLI skips TLS certificate checks for this repository

## Example

First, configure k8s Secret or ConfigMap using `extraVolumes` and `extraVolumeMounts` properties. 

Chart `values.yaml` example with using Secrets:

```yaml
...
api:
  ...
  extraVolumes:
  - name: cacerts-secret
    secret:
      secretName: cacerts
  extraVolumeMounts:
  - name: cacerts-secret
    mountPath: /usr/local/share/ca-certificates
    readOnly: true
...
```

Chart `values.yaml` example using Secrets and custom `CACERTS_DIR`:

```yaml
...
api:
  ...
  env:
    CACERTS_DIR: "/tmp/ca-certificates"
  extraVolumes:
  - name: cacerts-secret
    secret:
      secretName: cacerts
  extraVolumeMounts:
  - name: cacerts-secret
    mountPath: /tmp/ca-certificates
    readOnly: true
...
```

`cacerts-secret` Secret example:

```yaml
apiVersion: v1
kind: Secret
metadata:
   name: cacerts
type: Opaque
data:
  my-cacert: BASE64_ENCODED_STRING_XXXX
```

Example configuration of the `catalogs` property in the chart `values.yaml` file:

```yaml
 catalogs:
    [
       {
          /* Using CA certificate */
          ...
          "location": "https://chartmuseum.nydomain.fr/inseefrlab/ide",
          "caFile": "my-cacert",
        },
        {
          /* Skipping TLS verification */
          ...
          "location": "https://chartmuseum.nydomain.fr/inseefrlab/databases",
          "skipTlsVerify": true,
        }
    ]
```
