### PR TITLE
Upgrade keycloak adapter

### DIFF
--- a/onyxia-api/pom.xml
+++ b/onyxia-api/pom.xml
@@ -8,9 +8,9 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <parent>
-          <groupId>innovation.insee</groupId>
-          <artifactId>onyxia</artifactId>
-          <version>0.0.1-SNAPSHOT</version>
+        <groupId>innovation.insee</groupId>
+        <artifactId>onyxia</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-spring-boot-starter</artifactId>
-            <version>20.0.1</version>
+            <version>21.0.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Current keycloak adapter seems to be incompatible with keycloakx 20+, this PR bumps the keycloak adapter version to fix this issue.  
Note : this adapter is being deprecated by keycloak maintainers so we should get rid of it in favor of "standard" openidconnect. See #202