### PR TITLE
Add istio to region configuration

### DIFF
--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -52,7 +52,13 @@
         "expose": {
           "domain": "fakedomain.kub.example.com",
           "ingress": true,
-          "route": false
+          "route": false,
+          "istio": {
+            "enabled": false,
+            "gateways": [
+              "istio-system/example-gateway"
+            ]
+          }
         },
         "monitoring": {
           "URLPattern": "https://graphana.kub.example.com/$appIdSlug"

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
@@ -1009,6 +1009,8 @@ public class Region {
 
         private boolean route = false;
 
+        private IstioIngress istio;
+
         public void setDomain(String domain) {
             this.domain = domain;
         }
@@ -1039,6 +1041,36 @@ public class Region {
 
         public boolean getRoute() {
             return route;
+        }
+
+        public void setIstio(IstioIngress istio) {
+            this.istio = istio;
+        }
+
+        public IstioIngress getIstio() {
+            return istio;
+        }
+    }
+
+    public static class IstioIngress {
+        private boolean enabled = false;
+
+        private String[] gateways = new String[0];
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String[] getGateways() {
+            return gateways;
+        }
+
+        public void setGateways(String[] gateways) {
+            this.gateways = gateways;
         }
     }
 


### PR DESCRIPTION
Add support for specifying Istio ingress options via an object in region configuration.
The istio block is defined as a object to avoid multiple properties on Exposed-object. 
Example of expose object after this addition:
```json
   "expose": {
          "domain": "fakedomain.kub.example.com",
          "ingress": true,
          "route": false,
          "istio": {
            "enabled": false,
            "gateways": [
              "istio-system/example-gateway"
            ]
          }
        }
```

This PR inspired by https://github.com/InseeFrLab/onyxia-api/pull/227 (which can be closed). A corresponding PR in onyxia-web will be linked here.