### PR TITLE
Construct service urls from all ingress types (K8S ingress, Istio VirtualService, OpenShift Route)

### DIFF
--- a/helm-wrapper/pom.xml
+++ b/helm-wrapper/pom.xml
@@ -16,7 +16,6 @@
 
     <properties>
         <java.version>17</java.version>
-        <fabric8io.version>6.7.1</fabric8io.version>
     </properties>
 
     <distributionManagement>
@@ -66,7 +65,6 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
-            <version>${fabric8io.version}</version>
         </dependency>
 
         <dependency>

--- a/onyxia-api/pom.xml
+++ b/onyxia-api/pom.xml
@@ -123,6 +123,12 @@
             <artifactId>sts</artifactId>
             <version>2.20.85</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -31,7 +31,6 @@ import io.github.inseefrlab.helmwrapper.model.HelmInstaller;
 import io.github.inseefrlab.helmwrapper.model.HelmLs;
 import io.github.inseefrlab.helmwrapper.service.HelmInstallService;
 import io.github.inseefrlab.helmwrapper.service.HelmInstallService.MultipleServiceFound;
-
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
@@ -40,7 +39,6 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -431,5 +429,4 @@ public class HelmAppsService implements AppsService {
 
         return service;
     }
-
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -24,6 +24,7 @@ import fr.insee.onyxia.model.project.Project;
 import fr.insee.onyxia.model.region.Region;
 import fr.insee.onyxia.model.service.*;
 import io.fabric8.kubernetes.api.model.EventList;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -36,13 +37,14 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -355,35 +357,9 @@ public class HelmAppsService implements AppsService {
     private Service getServiceFromRelease(
             Region region, HelmLs release, String manifest, User user) {
         KubernetesClient client = kubernetesClientProvider.getUserClient(region, user);
-        InputStream inputStream =
-                new ByteArrayInputStream(manifest.getBytes(Charset.forName("UTF-8")));
-        List<HasMetadata> hasMetadatas = client.load(inputStream).items();
-        List<Ingress> ingresses =
-                hasMetadatas.stream()
-                        .filter(hasMetadata -> hasMetadata instanceof Ingress)
-                        .map(hasMetadata -> (Ingress) hasMetadata)
-                        .collect(Collectors.toList());
+
+        List<String> urls = getUrls(region, manifest, client);
         Service service = new Service();
-        List<String> urls = new ArrayList<>();
-        for (Ingress ingress : ingresses) {
-            try {
-                urls.addAll(
-                        ingress.getSpec().getRules().stream()
-                                .flatMap(
-                                        rule ->
-                                                rule.getHttp().getPaths().stream()
-                                                        .map(
-                                                                path ->
-                                                                        rule.getHost()
-                                                                                + path.getPath()))
-                                .map(url -> url.startsWith("http") ? url : "https://" + url)
-                                .collect(Collectors.toList()));
-            } catch (Exception e) {
-                System.out.println(
-                        "Warning : could not read urls from ingress "
-                                + ingress.getFullResourceName());
-            }
-        }
         service.setUrls(urls);
 
         service.setInstances(1);
@@ -458,5 +434,94 @@ public class HelmAppsService implements AppsService {
         service.setEvents(events);
 
         return service;
+    }
+    
+    private static List<String> getUrls(Region region, String manifest, KubernetesClient client) {
+        Region.Expose expose = region.getServices().getExpose();
+        boolean isIstioEnabled = expose.getIstio() != null && expose.getIstio().isEnabled();
+        boolean isServiceExposed = expose.getIngress() || expose.getRoute() || isIstioEnabled;
+        if (!isServiceExposed) {
+            return List.of();
+        }
+
+        List<HasMetadata> hasMetadata;
+        try (InputStream inputStream = new ByteArrayInputStream(manifest.getBytes(StandardCharsets.UTF_8))) {
+            hasMetadata = client.load(inputStream).items();
+        } catch (IOException e) {
+            throw new RuntimeException("Exception during loading manifest", e);
+        }
+
+        var urls = new ArrayList<String>();
+
+        if(expose.getIngress()) {
+            List<Ingress> ingresses = getResourceOfType(hasMetadata, Ingress.class).toList();
+
+            for (Ingress ingress : ingresses) {
+                try {
+                    urls.addAll(
+                            ingress.getSpec().getRules().stream()
+                                    .flatMap(
+                                            rule ->
+                                                    rule.getHttp().getPaths().stream()
+                                                            .map(
+                                                                    path ->
+                                                                            rule.getHost()
+                                                                                    + path.getPath()))
+                                    .toList());
+                } catch (Exception e) {
+                    System.out.println(
+                            "Warning : could not read urls from ingress "
+                                    + ingress.getFullResourceName());
+                }
+            }
+        } else if (expose.getRoute()) {
+            // https://docs.openshift.com/container-platform/4.13/rest_api/network_apis/route-route-openshift-io-v1.html#status-ingress
+            // https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html
+            List<GenericKubernetesResource> routes =
+                    getResourceOfType(hasMetadata, "route.openshift.io/v1", "Route").toList();
+
+            for (GenericKubernetesResource resource : routes) {
+                try {
+                    urls.add(resource.get("spec", "host"));
+                } catch (Exception e) {
+                    System.out.println(
+                            "Warning : could not read urls from OpenShift Route "
+                                    + resource.getFullResourceName());
+                }
+            }
+        } else if (isIstioEnabled) {
+            List<GenericKubernetesResource> virtualServices =
+                    getResourceOfType(hasMetadata, "networking.istio.io/", "VirtualService").toList();
+
+            for (GenericKubernetesResource resource : virtualServices) {
+                try {
+                    // For now we assume we have a simple VirtualService with no routing, thus the hosts are also  the URL.
+                    // One should consider to add support for 'spec/http[*]/match[*]/uri/prefix'
+                    urls.addAll(resource.get("spec", "hosts"));
+                } catch (Exception e) {
+                    System.out.println(
+                            "Warning : could not read urls from Istio Virtual Service "
+                                    + resource.getFullResourceName());
+                }
+            }
+        }
+
+        // Ensure every URL start with http-prefix
+        return urls.stream()
+                .map(url -> url.startsWith("http") ? url : "https://" + url)
+                .toList();
+    }
+
+    private static <T extends HasMetadata> Stream<T> getResourceOfType(List<HasMetadata> resourcesStream, Class<T> type) {
+        return resourcesStream
+                .stream()
+                .filter(type::isInstance)
+                .map(type::cast);
+    }
+
+    private static Stream<GenericKubernetesResource> getResourceOfType(List<HasMetadata> resourcesStream, String apiVersionPrefix, String kind) {
+        return getResourceOfType(resourcesStream, GenericKubernetesResource.class)
+                .filter(resource -> resource.getApiVersion().startsWith(apiVersionPrefix))
+                .filter(resource -> resource.getKind().equalsIgnoreCase(kind));
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolver.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolver.java
@@ -1,0 +1,105 @@
+package fr.insee.onyxia.api.services.impl;
+
+import fr.insee.onyxia.model.region.Region;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+public final class ServiceUrlResolver {
+    static List<String> getServiceUrls(Region region, String manifest, KubernetesClient client) {
+        Region.Expose expose = region.getServices().getExpose();
+        boolean isIstioEnabled = expose.getIstio() != null && expose.getIstio().isEnabled();
+        boolean isServiceExposed = expose.getIngress() || expose.getRoute() || isIstioEnabled;
+        if (!isServiceExposed) {
+            return List.of();
+        }
+
+        List<HasMetadata> hasMetadata;
+        try (InputStream inputStream = new ByteArrayInputStream(manifest.getBytes(StandardCharsets.UTF_8))) {
+            hasMetadata = client.load(inputStream).items();
+        } catch (IOException e) {
+            throw new RuntimeException("Exception during loading manifest", e);
+        }
+
+        var urls = new ArrayList<String>();
+
+        if (expose.getIngress()) {
+            List<Ingress> ingresses = getResourceOfType(hasMetadata, Ingress.class).toList();
+
+            for (Ingress ingress : ingresses) {
+                try {
+                    urls.addAll(
+                            ingress.getSpec().getRules()
+                                    .stream()
+                                    .flatMap(rule ->
+                                            rule.getHttp().getPaths()
+                                                    .stream()
+                                                    .map(path -> rule.getHost() + path.getPath())
+                                    )
+                                    .toList());
+                } catch (Exception e) {
+                    System.out.println(
+                            "Warning : could not read urls from ingress "
+                                    + ingress.getFullResourceName());
+                }
+            }
+        } else if (expose.getRoute()) {
+            // https://docs.openshift.com/container-platform/4.13/rest_api/network_apis/route-route-openshift-io-v1.html#status-ingress
+            // https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html
+            List<GenericKubernetesResource> routes =
+                    getResourceOfType(hasMetadata, "route.openshift.io/v1", "Route").toList();
+
+            for (GenericKubernetesResource resource : routes) {
+                try {
+                    urls.add(resource.get("spec", "host"));
+                } catch (Exception e) {
+                    System.out.println(
+                            "Warning : could not read urls from OpenShift Route "
+                                    + resource.getFullResourceName());
+                }
+            }
+        } else if (isIstioEnabled) {
+            List<GenericKubernetesResource> virtualServices =
+                    getResourceOfType(hasMetadata, "networking.istio.io/", "VirtualService").toList();
+
+            for (GenericKubernetesResource resource : virtualServices) {
+                try {
+                    // For now we assume we have a simple VirtualService with no routing, thus the hosts are also  the URL.
+                    // One should consider to add support for 'spec/http[*]/match[*]/uri/prefix'
+                    urls.addAll(resource.get("spec", "hosts"));
+                } catch (Exception e) {
+                    System.out.println(
+                            "Warning : could not read urls from Istio Virtual Service "
+                                    + resource.getFullResourceName());
+                }
+            }
+        }
+
+        // Ensure every URL start with http-prefix
+        return urls.stream()
+                .map(url -> url.startsWith("http") ? url : "https://" + url)
+                .toList();
+    }
+
+    private static <T extends HasMetadata> Stream<T> getResourceOfType(List<HasMetadata> resourcesStream, Class<T> type) {
+        return resourcesStream
+                .stream()
+                .filter(type::isInstance)
+                .map(type::cast);
+    }
+
+    private static Stream<GenericKubernetesResource> getResourceOfType(List<HasMetadata> resourcesStream, String apiVersionPrefix, String kind) {
+        return getResourceOfType(resourcesStream, GenericKubernetesResource.class)
+                .filter(resource -> resource.getApiVersion().startsWith(apiVersionPrefix))
+                .filter(resource -> resource.getKind().equalsIgnoreCase(kind));
+    }
+}

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolver.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolver.java
@@ -52,7 +52,9 @@ public final class ServiceUrlResolver {
                                     + ingress.getFullResourceName());
                 }
             }
-        } else if (expose.getRoute()) {
+        }
+
+        if (expose.getRoute()) {
             // https://docs.openshift.com/container-platform/4.13/rest_api/network_apis/route-route-openshift-io-v1.html#status-ingress
             // https://docs.openshift.com/container-platform/4.11/networking/routes/route-configuration.html
             List<GenericKubernetesResource> routes =
@@ -67,7 +69,9 @@ public final class ServiceUrlResolver {
                                     + resource.getFullResourceName());
                 }
             }
-        } else if (isIstioEnabled) {
+        }
+
+        if (isIstioEnabled) {
             List<GenericKubernetesResource> virtualServices =
                     getResourceOfType(hasMetadata, "networking.istio.io/", "VirtualService").toList();
 

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolverTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolverTest.java
@@ -1,0 +1,115 @@
+package fr.insee.onyxia.api.services.impl;
+
+import fr.insee.onyxia.model.region.Region;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@EnableKubernetesMockClient
+class ServiceUrlResolverTest {
+
+    private KubernetesClient kubernetesClient;
+    private final String ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH = "kubernetes-manifest/istio-virtualservice.yaml";
+    private final String INGRESS_MANIFEST_PATH = "kubernetes-manifest/k8s-ingress.yaml";
+    private final String OPENSHIFT_ROUTE_MANIFEST_PATH = "kubernetes-manifest/openshift-route.yaml";
+    private final String YAML_LINE_BREAK = "\n---\n";
+
+
+    @Test
+    void urls_should_be_empty() {
+        Region region = getRegionNoExposed();
+        var allManifest =
+                getManifest(ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH)
+                        + "\n---\n"
+                        + getManifest(INGRESS_MANIFEST_PATH)
+                        + "\n---\n"
+                        + getManifest(OPENSHIFT_ROUTE_MANIFEST_PATH);
+
+        List<String> urls = ServiceUrlResolver.getServiceUrls(region, allManifest, kubernetesClient);
+        assertEquals(List.of(), urls);
+    }
+
+    @Test
+    void urls_should_be_present_for_all_ingress_types() {
+        Region region = getRegionNoExposed();
+        region.getServices().getExpose().setIngress(true);
+        region.getServices().getExpose().setRoute(true);
+        region.getServices().getExpose().getIstio().setEnabled(true);
+        var allManifest = getManifest(ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH)
+                + YAML_LINE_BREAK
+                + getManifest(INGRESS_MANIFEST_PATH)
+                + YAML_LINE_BREAK
+                + getManifest(OPENSHIFT_ROUTE_MANIFEST_PATH);
+
+        List<String> urls = ServiceUrlResolver.getServiceUrls(region, allManifest, kubernetesClient);
+        List<String> expected = List.of("https://jupyter-python-3574-0.example.com/", "https://hello-openshift.example.com", "https://jupyter-python-3574-0.example.com");
+        assertEquals(expected, urls);
+    }
+
+    @Test
+    void k8s_ingress_should_be_included_in_urls() {
+        Region region = getRegionNoExposed();
+        region.getServices().getExpose().setIngress(true);
+        var manifest = getManifest(INGRESS_MANIFEST_PATH);
+
+        List<String> urls = ServiceUrlResolver.getServiceUrls(region, manifest, kubernetesClient);
+        assertEquals(List.of("https://jupyter-python-3574-0.example.com/"), urls);
+    }
+
+    private String getManifest(String manifestClassPath) {
+        try {
+            return new String(new ClassPathResource(manifestClassPath).getInputStream().readAllBytes(), UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void istio_virtual_service_should_be_included_in_urls() {
+        Region region = getRegionNoExposed();
+        region.getServices().getExpose().getIstio().setEnabled(true);
+        var manifest = "";
+
+        manifest = getManifest(ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH);
+
+        List<String> urls = ServiceUrlResolver.getServiceUrls(region, manifest, kubernetesClient);
+        assertEquals(List.of("https://jupyter-python-3574-0.example.com"), urls);
+    }
+
+    @Test
+    void openshift_route_should_be_included_in_urls() {
+        Region region = getRegionNoExposed();
+        region.getServices().getExpose().setRoute(true);
+        var manifest = "";
+
+        manifest = getManifest(OPENSHIFT_ROUTE_MANIFEST_PATH);
+
+        List<String> urls = ServiceUrlResolver.getServiceUrls(region, manifest, kubernetesClient);
+        assertEquals(List.of("https://hello-openshift.example.com"), urls);
+    }
+
+
+    private static Region getRegionNoExposed() {
+        Region.Expose expose = new Region.Expose();
+        expose.setIngress(false);
+        expose.setRoute(false);
+
+        Region.IstioIngress istio = new Region.IstioIngress();
+        istio.setEnabled(false);
+        expose.setIstio(istio);
+
+        Region.Services services = new Region.Services();
+        services.setExpose(expose);
+
+        var region = new Region();
+        region.setServices(services);
+        return region;
+    }
+}

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolverTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/services/impl/ServiceUrlResolverTest.java
@@ -1,26 +1,25 @@
 package fr.insee.onyxia.api.services.impl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import fr.insee.onyxia.model.region.Region;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.jupiter.api.Test;
-import org.springframework.core.io.ClassPathResource;
-
 import java.io.IOException;
 import java.util.List;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
 
 @EnableKubernetesMockClient
 class ServiceUrlResolverTest {
 
     private KubernetesClient kubernetesClient;
-    private final String ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH = "kubernetes-manifest/istio-virtualservice.yaml";
+    private final String ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH =
+            "kubernetes-manifest/istio-virtualservice.yaml";
     private final String INGRESS_MANIFEST_PATH = "kubernetes-manifest/k8s-ingress.yaml";
     private final String OPENSHIFT_ROUTE_MANIFEST_PATH = "kubernetes-manifest/openshift-route.yaml";
     private final String YAML_LINE_BREAK = "\n---\n";
-
 
     @Test
     void urls_should_be_empty() {
@@ -32,7 +31,8 @@ class ServiceUrlResolverTest {
                         + "\n---\n"
                         + getManifest(OPENSHIFT_ROUTE_MANIFEST_PATH);
 
-        List<String> urls = ServiceUrlResolver.getServiceUrls(region, allManifest, kubernetesClient);
+        List<String> urls =
+                ServiceUrlResolver.getServiceUrls(region, allManifest, kubernetesClient);
         assertEquals(List.of(), urls);
     }
 
@@ -42,14 +42,20 @@ class ServiceUrlResolverTest {
         region.getServices().getExpose().setIngress(true);
         region.getServices().getExpose().setRoute(true);
         region.getServices().getExpose().getIstio().setEnabled(true);
-        var allManifest = getManifest(ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH)
-                + YAML_LINE_BREAK
-                + getManifest(INGRESS_MANIFEST_PATH)
-                + YAML_LINE_BREAK
-                + getManifest(OPENSHIFT_ROUTE_MANIFEST_PATH);
+        var allManifest =
+                getManifest(ISTIO_VIRTUAL_SERVICE_MANIFEST_PATH)
+                        + YAML_LINE_BREAK
+                        + getManifest(INGRESS_MANIFEST_PATH)
+                        + YAML_LINE_BREAK
+                        + getManifest(OPENSHIFT_ROUTE_MANIFEST_PATH);
 
-        List<String> urls = ServiceUrlResolver.getServiceUrls(region, allManifest, kubernetesClient);
-        List<String> expected = List.of("https://jupyter-python-3574-0.example.com/", "https://hello-openshift.example.com", "https://jupyter-python-3574-0.example.com");
+        List<String> urls =
+                ServiceUrlResolver.getServiceUrls(region, allManifest, kubernetesClient);
+        List<String> expected =
+                List.of(
+                        "https://jupyter-python-3574-0.example.com/",
+                        "https://hello-openshift.example.com",
+                        "https://jupyter-python-3574-0.example.com");
         assertEquals(expected, urls);
     }
 
@@ -65,7 +71,9 @@ class ServiceUrlResolverTest {
 
     private String getManifest(String manifestClassPath) {
         try {
-            return new String(new ClassPathResource(manifestClassPath).getInputStream().readAllBytes(), UTF_8);
+            return new String(
+                    new ClassPathResource(manifestClassPath).getInputStream().readAllBytes(),
+                    UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -94,7 +102,6 @@ class ServiceUrlResolverTest {
         List<String> urls = ServiceUrlResolver.getServiceUrls(region, manifest, kubernetesClient);
         assertEquals(List.of("https://hello-openshift.example.com"), urls);
     }
-
 
     private static Region getRegionNoExposed() {
         Region.Expose expose = new Region.Expose();

--- a/onyxia-api/src/test/resources/kubernetes-manifest/istio-virtualservice.yaml
+++ b/onyxia-api/src/test/resources/kubernetes-manifest/istio-virtualservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: jupyter-python-3574-ui
+spec:
+  gateways:
+    - istio-system/my-gateway
+  hosts:
+    - jupyter-python-3574-0.example.com
+  http:
+    - match:
+        - uri:
+            prefix: /
+      name: ui
+      route:
+        - destination:
+            host: jupyter-python-3574
+            port:
+              number: 8888

--- a/onyxia-api/src/test/resources/kubernetes-manifest/k8s-ingress.yaml
+++ b/onyxia-api/src/test/resources/kubernetes-manifest/k8s-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jupyter-python-3574-ui
+spec:
+  rules:
+    - host: jupyter-python-3574-0.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: jupyter-python-3574
+                port:
+                  number: 8888
+            path: /
+            pathType: Prefix
+  tls:
+    - hosts:
+        - jupyter-python-3574-0.example.com

--- a/onyxia-api/src/test/resources/kubernetes-manifest/openshift-route.yaml
+++ b/onyxia-api/src/test/resources/kubernetes-manifest/openshift-route.yaml
@@ -1,0 +1,12 @@
+# https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html#nw-creating-a-route_route-configuration
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hello-openshift
+spec:
+  host: hello-openshift.example.com
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: hello-openshift

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,26 @@
 
     </distributionManagement>
     <properties>
+        <fabric8io.version>6.7.1</fabric8io.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client</artifactId>
+                <version>${fabric8io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-server-mock</artifactId>
+                <version>${fabric8io.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
Background:
The urls-field from the onyxia-api is used in frontend to decide if the "open" button is displayed or not.

Before this PR: Urls would only be exposed to frontend if there was a Kubernetes Ingress resource present. That would result in no urls (and thus no 'Open' button) in the frontend if you used Istio VirtualService or OpenShift Route and not creating a Kubernetes Ingress resource

After:
We use `regions.services.expose.XX` to decided which resources we should check for when fetching/constructing urls. Support for Istio VirtualService and OpenShift Route are added. The implementation can return multiple urls (same as old behavior), e.g. urls for all types if multiple resources for ingress are created (don't know of any use cases for this, but it is supported).
Code for this url resolving is refactored to it's own class. Tests are added.
I would recommend starting the review by taking a look at `ServiceUrlResolverTest` first.

For now only hosts (and not full paths) are implemented if the type is istio VirtualSerivce or OpenShift Route

PS: I have not tested with OpenShift Route myself, only looked at their documentation and written a test based on that.
