### PR TITLE
Fix onboarding single namespace and improve response http codes for exceptions

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/RestExceptionHandler.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/RestExceptionHandler.java
@@ -1,0 +1,15 @@
+package fr.insee.onyxia.api.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ResponseStatus(value = HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AccessDeniedException.class)
+    public void handleAccessDeniedException(Exception ignored) {}
+}

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
@@ -1,5 +1,6 @@
 package fr.insee.onyxia.api.controller.api.onboarding;
 
+import fr.insee.onyxia.api.controller.exception.NamespaceAlreadyExistException;
 import fr.insee.onyxia.api.controller.exception.OnboardingDisabledException;
 import fr.insee.onyxia.api.services.UserProvider;
 import fr.insee.onyxia.api.services.impl.kubernetes.KubernetesService;
@@ -43,6 +44,9 @@ public class OnboardingController {
     @PostMapping
     public void onboard(
             @Parameter(hidden = true) Region region, @RequestBody OnboardingRequest request) {
+        if (region.getServices().isSingleNamespace()) {
+            throw new NamespaceAlreadyExistException();
+        }
         if (!region.getServices().isAllowNamespaceCreation()) {
             throw new OnboardingDisabledException();
         }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
@@ -50,6 +50,7 @@ public class OnboardingController {
         if (!region.getServices().isAllowNamespaceCreation()) {
             throw new OnboardingDisabledException();
         }
+
         checkPermissions(region, request);
         final KubernetesService.Owner owner = new KubernetesService.Owner();
         if (request.getGroup() != null) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/exception/OnboardingDisabledException.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/exception/OnboardingDisabledException.java
@@ -3,7 +3,7 @@ package fr.insee.onyxia.api.controller.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value = HttpStatus.NOT_IMPLEMENTED)
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
 public class OnboardingDisabledException extends RuntimeException {
     public OnboardingDisabledException() {
         super("Onboarding is disabled on this onyxia instance");

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingControllerTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingControllerTest.java
@@ -1,0 +1,73 @@
+package fr.insee.onyxia.api.controller.api.onboarding;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import fr.insee.onyxia.api.configuration.BaseTest;
+import fr.insee.onyxia.api.configuration.SecurityConfig;
+import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
+import fr.insee.onyxia.api.services.UserProvider;
+import fr.insee.onyxia.api.services.impl.kubernetes.KubernetesService;
+import fr.insee.onyxia.api.services.utils.HttpRequestUtils;
+import fr.insee.onyxia.api.user.OnyxiaUserProvider;
+import fr.insee.onyxia.model.User;
+import fr.insee.onyxia.model.region.Region;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OnboardingController.class)
+class OnboardingControllerTest extends BaseTest {
+
+    @Autowired private MockMvc mockMvc;
+
+    @MockBean private UserProvider userProvider;
+    @MockBean private RegionsConfiguration regionsConfiguration;
+
+    @MockBean private HttpRequestUtils httpRequestUtils;
+    @MockBean private SecurityConfig securityConfig;
+    @MockBean private OnyxiaUserProvider onyxiaUserProvider;
+    @MockBean private KubernetesService kubernetesService;
+
+    @Test
+    public void should_not_create_namespace_when_single_project() throws Exception {
+        Region region = new Region();
+        Region.Services servicesConfiguration = new Region.Services();
+        servicesConfiguration.setSingleNamespace(true);
+        region.setServices(servicesConfiguration);
+        when(regionsConfiguration.getDefaultRegion()).thenReturn(region);
+        mockMvc.perform(post("/onboarding").content("{}").contentType(APPLICATION_JSON))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    public void should_not_create_namespace_when_allow_namespace_creation_is_false()
+            throws Exception {
+        Region region = new Region();
+        Region.Services servicesConfiguration = new Region.Services();
+        servicesConfiguration.setSingleNamespace(false);
+        servicesConfiguration.setAllowNamespaceCreation(false);
+        region.setServices(servicesConfiguration);
+        when(regionsConfiguration.getDefaultRegion()).thenReturn(region);
+        mockMvc.perform(post("/onboarding").content("{}").contentType(APPLICATION_JSON))
+                .andExpect(status().isNotImplemented());
+    }
+
+    @Test
+    public void should_create_namespace() throws Exception {
+        Region region = new Region();
+        Region.Services servicesConfiguration = new Region.Services();
+        servicesConfiguration.setSingleNamespace(false);
+        servicesConfiguration.setAllowNamespaceCreation(true);
+        region.setServices(servicesConfiguration);
+        when(regionsConfiguration.getDefaultRegion()).thenReturn(region);
+        when(userProvider.getUser(any())).thenReturn(User.newInstance().setIdep("default").build());
+        mockMvc.perform(post("/onboarding").content("{}").contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+}

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingControllerTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingControllerTest.java
@@ -55,7 +55,7 @@ class OnboardingControllerTest extends BaseTest {
         region.setServices(servicesConfiguration);
         when(regionsConfiguration.getDefaultRegion()).thenReturn(region);
         mockMvc.perform(post("/onboarding").content("{}").contentType(APPLICATION_JSON))
-                .andExpect(status().isNotImplemented());
+                .andExpect(status().isBadRequest());
     }
 
     @Test


### PR DESCRIPTION
Starting from onyxia-web v2.21.0 (https://github.com/InseeFrLab/onyxia-web/compare/v2.20.0...v2.21.0) a call to `/onboarding` from the splash screen of onyxia-web was added (see https://github.com/InseeFrLab/onyxia-web/issues/545 ).  This resulted in a issues for single namespace installations, and users would get stuck on the splash screen.
This PR fixes this.

This PR also include:
- Throwing `AccessDeniedException` now result in http status code 403 FORBIDDEN (earlier it was 500 INTERNAL SERVER ERROR)
- Throwing `OnboardingDisabledException` now result in http status code 400 BAD REQUEST (earlier it was 501 NOT IMPLEMENTED)