### PR TITLE
Prevent crash when failing to parse manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 .vscode
 onyxia-api/src/main/resources/application.properties.local
 onyxia-api/src/main/resources/regions.json.local
+target

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -352,9 +352,20 @@ public class HelmAppsService implements AppsService {
             Region region, HelmLs release, String manifest, User user) {
         KubernetesClient client = kubernetesClientProvider.getUserClient(region, user);
 
-        List<String> urls = getServiceUrls(region, manifest, client);
         Service service = new Service();
-        service.setUrls(urls);
+
+        try {
+            List<String> urls = getServiceUrls(region, manifest, client);
+            service.setUrls(urls);
+        } catch (Exception e) {
+            System.out.println(
+                    "Warning : Failed to retrieve URLS for release "
+                            + release.getName()
+                            + " namespace "
+                            + release.getNamespace());
+            e.printStackTrace();
+            service.setUrls(List.of());
+        }
 
         service.setInstances(1);
 


### PR DESCRIPTION
See #241   
I was not able to make the parser parse some manifests but at least this PR prevent crashes when the manifest is not properly read.  
Note that in this case Onyxia wont be able to properly display the service URLS / open button to the user. But at least the "my services" endpoint won't crash anymore.