### PR TITLE
fix token claims

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/OIDCConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/OIDCConfiguration.java
@@ -136,6 +136,9 @@ public class OIDCConfiguration {
             user.setEmail(userInfo.getClaimAsString("email"));
             user.setNomComplet(userInfo.getClaimAsString("name"));
             user.setGroups(userInfo.getClaimAsStringList(groupsClaim));
+            user.getAttributes().putAll(userInfo.getClaims());
+            user.getAttributes().put("sub", userInfo.getSubject());
+            user.getAttributes().put("access_token", userInfo.getTokenValue());
             return user;
         };
     }


### PR DESCRIPTION
Parsing of additional token claims was lost in the migration from keycloak to oidc, sorry about that