### PR TITLE
Feat: Add support for arbitrary custom values in regions.json

### DIFF
--- a/docs/region-configuration.md
+++ b/docs/region-configuration.md
@@ -65,6 +65,7 @@ Users can work on Onyxia as a User or as a Group to which they belong. Each user
 | `quotas` | | Properties setting quotas on how many resources a user can get on the services provider. | See [Quotas properties](#quotas-properties) |
 | `defaultConfiguration` | | Default configuration on services that a user can override. For client purposes only. | See [Default Configuration](#default-configuration-properties) |
 | `customInitScript` | | This can be used to customize user environments using a regional script executed by some users' pods. | See [CustomInitScript properties](#custom-init-script-properties) |
+| `customValues` | | This can be used to specify custom values thath should be avaiable in the underlaying helm chart when a service is launched. Nested values are supported. | ` "customValues": {"myCustomKey": "myValue", "myNestedCustomKey": {"nestedKey": "nestedValue"} }` |
 
 ### CustomInitScript properties
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -240,6 +240,7 @@ public class MyLabController {
         User user = userProvider.getUser(region);
         Map<String, Object> fusion = new HashMap<>();
         fusion.putAll((Map<String, Object>) requestDTO.getOptions());
+        fusion.putAll(region.getServices().getCustomValues());
         return helmAppsService.installApp(
                 region, project, requestDTO, catalogId, pkg, user, fusion, skipTlsVerify, caFile);
     }

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
@@ -196,12 +196,22 @@ public class Region {
         private K8sPublicEndpoint k8sPublicEndpoint = new K8sPublicEndpoint();
         private CustomInitScript customInitScript = new CustomInitScript();
 
+        private Map<String, Object> customValues = new HashMap<>();
+
         public DefaultConfiguration getDefaultConfiguration() {
             return defaultConfiguration;
         }
 
         public void setDefaultConfiguration(DefaultConfiguration defaultConfiguration) {
             this.defaultConfiguration = defaultConfiguration;
+        }
+
+        public Map<String, Object> getCustomValues() {
+            return customValues;
+        }
+
+        public void setCustomValues(Map<String, Object> customValues) {
+            this.customValues = customValues;
         }
 
         public CustomInitScript getCustomInitScript() {


### PR DESCRIPTION
**Background**: As we are developing our services helm charts we need to inject some values per region (values that are not a part of region.json today). We don’t want to make constant changes (and releases) to the onyxia-api (several reasons for that), and a suggestion would therefore be to have a field in regions.json where one can add arbitrary values to be injected/made available into the charts. 

**Solution proposed in this PR:**

Custom values can be added to regions.json via the field "customValues" and will then be accessible in the helm chart.
E.g. in `regions.json`:
```yaml
"services":
 …
 "customValues": {
    "myCustomKey": "myValue",
    "myNestedCustomKey": {
      "nestedKey": "nestedValue"
    }
  }
}
```
would result in the properties `myCustomKey` and `myNestedCustomKey.nestedKey` being available in the helm chart:
<img width="524" alt="image" src="https://github.com/InseeFrLab/onyxia-api/assets/10381866/ef7d89fb-6fce-4c76-b107-05b7d3e662d4">
 

Should the field be named `customValues` or something else?
Does the frontend need any changes to accommodate for this? I guess there might be use cases where these custom values would be configurable? 

