### PR TITLE
Delete values.yaml file after use

### DIFF
--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
@@ -60,7 +60,9 @@ public class HelmInstallService {
                 throw new IllegalArgumentException(
                         "Invalid release name "
                                 + name
-                                + " , must match regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$ and the length must not be longer than 53");
+                                + " , must match regex "
+                                + helmNamePattern
+                                + " and the length must not be longer than 53");
             }
             safeConcat(command, name + " ");
         } else {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -177,6 +177,10 @@ public class HelmAppsService implements AppsService {
             return List.of(res.getManifest());
         } catch (IllegalArgumentException e) {
             throw new AccessDeniedException(e.getMessage());
+        } finally {
+            if (!values.delete()) {
+                LOGGER.warn("Failed to delete values file, path {}", values.getAbsolutePath());
+            }
         }
     }
 


### PR DESCRIPTION
Previously the file would continue to be on `/tmp` even after the service was installed. 