### PR TITLE
Chore: Bump action artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build with Maven
         run: mvn -B package
       - name: Upload jar
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jar
           path: onyxia-api/target/*.jar
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download jar
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jar
           path: onyxia-api/target


### PR DESCRIPTION
Apparently this is a major change with performance optimisation see https://github.com/actions/upload-artifact/releases/tag/v4.0.0