### PR TITLE
Set database catalogs as latest version only by default

### DIFF
--- a/onyxia-api/src/main/resources/catalogs.json
+++ b/onyxia-api/src/main/resources/catalogs.json
@@ -34,7 +34,7 @@
         "user": true,
         "project": true
       },
-      "multipleServicesMode" : "skipPatches"
+      "multipleServicesMode" : "latest"
     },
     {
       "id": "automation",


### PR DESCRIPTION
Continuing the effort to reduce the network load Onyxia uses by default, set the database catalog as `latest` version only by default.  
With this PR, all catalogs will be `latest` by default