### PR TITLE
Refactor field based bean injection to constructor based

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/Application.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/Application.java
@@ -19,7 +19,6 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableAsync(proxyTargetClass = true)
 public class Application {
 
-    // logger
     private static final Logger LOGGER = LoggerFactory.getLogger(Application.class);
 
     public static void main(String[] args) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogFilter.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogFilter.java
@@ -4,15 +4,18 @@ import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CatalogFilter {
 
-    @Autowired private RegionsConfiguration regionsConfiguration;
+    private final RegionsConfiguration regionsConfiguration;
 
     private Logger LOGGER = LoggerFactory.getLogger(CatalogFilter.class);
+
+    public CatalogFilter(RegionsConfiguration regionsConfiguration) {
+        this.regionsConfiguration = regionsConfiguration;
+    }
 
     public List<CatalogWrapper> filterCatalogs(List<CatalogWrapper> catalogs) {
         return catalogs;

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/WebConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/WebConfiguration.java
@@ -11,9 +11,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfiguration implements WebMvcConfigurer {
 
-    @Autowired RegionResolver regionResolver;
+    private final RegionResolver regionResolver;
 
-    @Autowired ProjectResolver projectResolver;
+    private final ProjectResolver projectResolver;
+
+    @Autowired
+    public WebConfiguration(RegionResolver regionResolver, ProjectResolver projectResolver) {
+        this.regionResolver = regionResolver;
+        this.projectResolver = projectResolver;
+    }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecks.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecks.java
@@ -16,10 +16,20 @@ import org.springframework.context.event.EventListener;
 public class CompatibilityChecks {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompatibilityChecks.class);
-    @Autowired RegionsConfiguration regionsConfiguration;
-    @Autowired KubernetesClientProvider kubernetesClientProvider;
+    private final RegionsConfiguration regionsConfiguration;
+    private final KubernetesClientProvider kubernetesClientProvider;
 
-    @Autowired HelmVersionService helmVersionService;
+    private final HelmVersionService helmVersionService;
+
+    @Autowired
+    public CompatibilityChecks(
+            RegionsConfiguration regionsConfiguration,
+            KubernetesClientProvider kubernetesClientProvider,
+            HelmVersionService helmVersionService) {
+        this.regionsConfiguration = regionsConfiguration;
+        this.kubernetesClientProvider = kubernetesClientProvider;
+        this.helmVersionService = helmVersionService;
+    }
 
     @EventListener(ContextRefreshedEvent.class)
     public void checkHelm() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/HelmClientProvider.java
@@ -1,20 +1,16 @@
 package fr.insee.onyxia.api.configuration.kubernetes;
 
-import fr.insee.onyxia.api.configuration.SecurityConfig;
 import fr.insee.onyxia.model.User;
 import fr.insee.onyxia.model.region.Region;
 import io.github.inseefrlab.helmwrapper.configuration.HelmConfiguration;
 import io.github.inseefrlab.helmwrapper.service.HelmInstallService;
 import io.github.inseefrlab.helmwrapper.service.HelmRepoService;
 import io.github.inseefrlab.helmwrapper.service.HelmVersionService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class HelmClientProvider {
-
-    @Autowired private final SecurityConfig securityConfig = new SecurityConfig();
 
     @Bean
     public HelmRepoService defaultHelmRepoService() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/kubernetes/KubernetesClientProvider.java
@@ -1,6 +1,5 @@
 package fr.insee.onyxia.api.configuration.kubernetes;
 
-import fr.insee.onyxia.api.configuration.SecurityConfig;
 import fr.insee.onyxia.model.User;
 import fr.insee.onyxia.model.region.Region;
 import io.fabric8.kubernetes.client.Config;
@@ -10,15 +9,12 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class KubernetesClientProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesClientProvider.class);
-
-    @Autowired private SecurityConfig securityConfig;
 
     /**
      * This returns the root client which has extended permissions. Currently cluster-admin. User

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfiguration.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -25,16 +27,23 @@ import org.springframework.core.io.support.PropertySourceFactory;
 @ConfigurationProperties
 public class CatalogsConfiguration {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CatalogsConfiguration.class);
+
     private String catalogs;
 
     private List<CatalogWrapper> resolvedCatalogs;
 
-    @Autowired private ObjectMapper mapper;
+    private final ObjectMapper mapper;
+
+    @Autowired
+    public CatalogsConfiguration(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
 
     @PostConstruct
     public void load() throws Exception {
         resolvedCatalogs = Arrays.asList(mapper.readValue(catalogs, CatalogWrapper[].class));
-        System.out.println("Serving " + resolvedCatalogs.size() + " catalogs");
+        LOGGER.info("Serving {} catalogs", resolvedCatalogs.size());
     }
 
     public List<CatalogWrapper> getResolvedCatalogs() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/RegionsConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/RegionsConfiguration.java
@@ -32,7 +32,12 @@ public class RegionsConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(RegionsConfiguration.class);
     private String regions;
     private List<Region> resolvedRegions;
-    @Autowired private ObjectMapper mapper;
+    private final ObjectMapper mapper;
+
+    @Autowired
+    public RegionsConfiguration(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
 
     @PostConstruct
     public void load() throws Exception {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/RegionsConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/RegionsConfiguration.java
@@ -49,27 +49,24 @@ public class RegionsConfiguration {
                                 .getAuthenticationMode()
                                 .equals(Region.Services.AuthenticationMode.SERVICEACCOUNT)) {
                             LOGGER.warn(
-                                    "Using serviceAccount authentication for region "
-                                            + region.getId()
-                                            + ". Onyxia will deploy services using it's own global permissions, this may be a security issue.");
+                                    "Using serviceAccount authentication for region {}. Onyxia will deploy services using it's own global permissions, this may be a security issue.",
+                                    region.getId());
                         }
 
                         if (region.getServices()
                                 .getAuthenticationMode()
                                 .equals(Region.Services.AuthenticationMode.IMPERSONATE)) {
                             LOGGER.info(
-                                    "Using impersonation authentication for region "
-                                            + region.getId()
-                                            + ".");
+                                    "Using impersonation authentication for region {}.",
+                                    region.getId());
                         }
 
                         if (region.getServices()
                                 .getAuthenticationMode()
                                 .equals(Region.Services.AuthenticationMode.TOKEN_PASSTHROUGH)) {
                             LOGGER.info(
-                                    "Using token passthrough authentication for region "
-                                            + region.getId()
-                                            + ". User token will be used by Onyxia to interact with the API Server.");
+                                    "Using token passthrough authentication for region {}. User token will be used by Onyxia to interact with the API Server.",
+                                    region.getId());
                         }
                     }
                 });
@@ -82,7 +79,7 @@ public class RegionsConfiguration {
     }
 
     public Region getDefaultRegion() {
-        return resolvedRegions.get(0);
+        return resolvedRegions.getFirst();
     }
 
     public String getRegions() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -29,11 +29,19 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @SecurityRequirement(name = "auth")
 public class MyLabController {
-    @Autowired private AppsService helmAppsService;
+    private final AppsService helmAppsService;
 
-    @Autowired private UserProvider userProvider;
+    private final UserProvider userProvider;
 
-    @Autowired private CatalogService catalogService;
+    private final CatalogService catalogService;
+
+    @Autowired
+    public MyLabController(
+            AppsService helmAppsService, UserProvider userProvider, CatalogService catalogService) {
+        this.helmAppsService = helmAppsService;
+        this.userProvider = userProvider;
+        this.catalogService = catalogService;
+    }
 
     @Operation(
             summary = "List the services installed in a namespace.",

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/QuotaController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/QuotaController.java
@@ -35,9 +35,15 @@ public class QuotaController {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QuotaController.class);
 
-    @Autowired private KubernetesService kubernetesService;
+    private final KubernetesService kubernetesService;
 
-    @Autowired private UserProvider userProvider;
+    private final UserProvider userProvider;
+
+    @Autowired
+    public QuotaController(KubernetesService kubernetesService, UserProvider userProvider) {
+        this.kubernetesService = kubernetesService;
+        this.userProvider = userProvider;
+    }
 
     @Operation(
             summary = "Obtain the quota for a namespace.",
@@ -211,15 +217,7 @@ public class QuotaController {
         return kubernetesService;
     }
 
-    public void setKubernetesService(KubernetesService kubernetesService) {
-        this.kubernetesService = kubernetesService;
-    }
-
     public UserProvider getUserProvider() {
         return userProvider;
-    }
-
-    public void setUserProvider(UserProvider userProvider) {
-        this.userProvider = userProvider;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/QuotaController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/QuotaController.java
@@ -112,8 +112,7 @@ public class QuotaController {
     public void applyQuota(
             @Parameter(hidden = true) Region region,
             @Parameter(hidden = true) Project project,
-            @RequestBody Quota quota)
-            throws IllegalAccessException {
+            @RequestBody Quota quota) {
         checkQuotaModificationIsAllowed(region);
         final Owner owner = getOwner(region, project);
         if (owner.getType() == Owner.OwnerType.USER) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/onboarding/OnboardingController.java
@@ -24,9 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "auth")
 public class OnboardingController {
 
-    @Autowired private KubernetesService kubernetesService;
+    private final KubernetesService kubernetesService;
 
-    @Autowired private UserProvider userProvider;
+    private final UserProvider userProvider;
+
+    @Autowired
+    public OnboardingController(KubernetesService kubernetesService, UserProvider userProvider) {
+        this.kubernetesService = kubernetesService;
+        this.userProvider = userProvider;
+    }
 
     @Operation(
             summary = "Init a namespace for a user or a group.",

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/user/UserController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/user/UserController.java
@@ -17,7 +17,12 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "auth")
 public class UserController {
 
-    @Autowired private OnyxiaUserProvider userProvider;
+    private final OnyxiaUserProvider userProvider;
+
+    @Autowired
+    public UserController(OnyxiaUserProvider userProvider) {
+        this.userProvider = userProvider;
+    }
 
     @GetMapping("/info")
     public OnyxiaUser userInfo(@Parameter(hidden = true) Region region) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/ProjectResolver.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/ProjectResolver.java
@@ -50,7 +50,7 @@ public class ProjectResolver implements HandlerMethodArgumentResolver {
                                         webDataBinderFactory));
 
         if (StringUtils.isBlank(project)) {
-            return user.getProjects().get(0);
+            return user.getProjects().getFirst();
         } else {
             Project resolvedProject =
                     user.getProjects().stream()

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/ProjectResolver.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/ProjectResolver.java
@@ -4,7 +4,6 @@ import fr.insee.onyxia.api.user.OnyxiaUserProvider;
 import fr.insee.onyxia.model.OnyxiaUser;
 import fr.insee.onyxia.model.project.Project;
 import fr.insee.onyxia.model.region.Region;
-import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
@@ -18,11 +17,15 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Service
 public class ProjectResolver implements HandlerMethodArgumentResolver {
 
-    @Autowired private HttpServletRequest request;
+    private final RegionResolver regionResolver;
 
-    @Autowired private RegionResolver regionResolver;
+    private final OnyxiaUserProvider userProvider;
 
-    private OnyxiaUserProvider userProvider;
+    @Autowired
+    public ProjectResolver(RegionResolver regionResolver, OnyxiaUserProvider userProvider) {
+        this.regionResolver = regionResolver;
+        this.userProvider = userProvider;
+    }
 
     @Override
     public boolean supportsParameter(MethodParameter methodParameter) {
@@ -60,14 +63,5 @@ public class ProjectResolver implements HandlerMethodArgumentResolver {
             }
             return resolvedProject;
         }
-    }
-
-    @Autowired
-    public void setUserProvider(OnyxiaUserProvider userProvider) {
-        this.userProvider = userProvider;
-    }
-
-    public OnyxiaUserProvider getUserProvider() {
-        return userProvider;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/RegionResolver.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/RegionResolver.java
@@ -30,8 +30,7 @@ public class RegionResolver implements HandlerMethodArgumentResolver {
             MethodParameter methodParameter,
             ModelAndViewContainer modelAndViewContainer,
             NativeWebRequest nativeWebRequest,
-            WebDataBinderFactory webDataBinderFactory)
-            throws Exception {
+            WebDataBinderFactory webDataBinderFactory) {
         String region = nativeWebRequest.getHeader("ONYXIA-REGION");
         Region defaultRegion = regionsConfiguration.getDefaultRegion();
         if (region != null) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/RegionResolver.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/utils/RegionResolver.java
@@ -2,7 +2,6 @@ package fr.insee.onyxia.api.controller.api.utils;
 
 import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
 import fr.insee.onyxia.model.region.Region;
-import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Service;
@@ -14,9 +13,12 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Service
 public class RegionResolver implements HandlerMethodArgumentResolver {
 
-    @Autowired private HttpServletRequest request;
+    private final RegionsConfiguration regionsConfiguration;
 
-    @Autowired private RegionsConfiguration regionsConfiguration;
+    @Autowired
+    public RegionResolver(RegionsConfiguration regionsConfiguration) {
+        this.regionsConfiguration = regionsConfiguration;
+    }
 
     @Override
     public boolean supportsParameter(MethodParameter methodParameter) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/CatalogController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/CatalogController.java
@@ -150,7 +150,7 @@ public class CatalogController {
     public List<Chart> getCharts(@PathVariable String catalogId, @PathVariable String chartName) {
         List<Chart> charts =
                 catalogService.getCharts(catalogId, chartName).orElseThrow(NotFoundException::new);
-        charts.stream().forEach(this::addCustomOnyxiaProperties);
+        charts.forEach(this::addCustomOnyxiaProperties);
         return charts;
     }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/CatalogController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/CatalogController.java
@@ -29,7 +29,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CatalogController {
 
-    @Autowired private CatalogService catalogService;
+    private final CatalogService catalogService;
+
+    @Autowired
+    public CatalogController(CatalogService catalogService) {
+        this.catalogService = catalogService;
+    }
 
     @Operation(
             summary = "List available catalogs and packages for installing.",

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/ConfigurationController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/ConfigurationController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,13 +19,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/public")
 public class ConfigurationController {
 
-    @Autowired(required = false)
-    private BuildProperties build;
+    private final BuildProperties build;
 
-    @Autowired(required = false)
-    private OIDCConfiguration oidcConfiguration;
+    private final OIDCConfiguration oidcConfiguration;
 
-    @Autowired private RegionsConfiguration regionsConfiguration;
+    private final RegionsConfiguration regionsConfiguration;
+
+    @Autowired
+    public ConfigurationController(
+            BuildProperties build,
+            Optional<OIDCConfiguration> oidcConfiguration,
+            RegionsConfiguration regionsConfiguration) {
+        this.build = build;
+        this.oidcConfiguration = oidcConfiguration.orElse(null);
+        this.regionsConfiguration = regionsConfiguration;
+    }
 
     @Operation(
             summary = "Get this Onyxia API full configuration description.",
@@ -47,14 +56,6 @@ public class ConfigurationController {
             appInfo.setOidcConfiguration(OIDCConfiguration);
         }
         return appInfo;
-    }
-
-    public OIDCConfiguration getOidcConfiguration() {
-        return oidcConfiguration;
-    }
-
-    public void setOidcConfiguration(OIDCConfiguration oidcConfiguration) {
-        this.oidcConfiguration = oidcConfiguration;
     }
 
     @Schema(description = "")

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/ConfigurationController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/ConfigurationController.java
@@ -92,7 +92,7 @@ public class ConfigurationController {
     }
 
     @Schema(description = "")
-    public class BuildInfo {
+    public static class BuildInfo {
         @Schema(description = "")
         private String version;
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/IPController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/IPController.java
@@ -16,7 +16,12 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @RequestMapping("/public")
 public class IPController {
 
-    @Autowired HttpRequestUtils httpRequestUtils;
+    private final HttpRequestUtils httpRequestUtils;
+
+    @Autowired
+    public IPController(HttpRequestUtils httpRequestUtils) {
+        this.httpRequestUtils = httpRequestUtils;
+    }
 
     @Operation(
             summary = "Get your public IP address.",
@@ -30,14 +35,6 @@ public class IPController {
                         ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
                                 .getRequest()));
         return ip;
-    }
-
-    public HttpRequestUtils getHttpRequestUtils() {
-        return httpRequestUtils;
-    }
-
-    public void setHttpRequestUtils(HttpRequestUtils httpRequestUtils) {
-        this.httpRequestUtils = httpRequestUtils;
     }
 
     @Schema(description = "")

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/RegionsController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/pub/RegionsController.java
@@ -15,7 +15,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class RegionsController {
 
-    @Autowired private RegionsConfiguration regionsConfiguration;
+    private final RegionsConfiguration regionsConfiguration;
+
+    @Autowired
+    public RegionsController(RegionsConfiguration regionsConfiguration) {
+        this.regionsConfiguration = regionsConfiguration;
+    }
 
     @Operation(
             summary = "Get Onyxia API regions configurations.",

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
@@ -19,14 +19,22 @@ public class CatalogRefresher implements ApplicationRunner {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CatalogRefresher.class);
 
-    @Autowired private Catalogs catalogs;
+    private final Catalogs catalogs;
+    private final CatalogLoader catalogLoader;
+    private final long refreshTime;
+    private final HelmRepoService helmRepoService;
 
-    @Autowired private CatalogLoader catalogLoader;
-
-    @Value("${catalogs.refresh.ms}")
-    private long refreshTime;
-
-    @Autowired private HelmRepoService helmRepoService;
+    @Autowired
+    public CatalogRefresher(
+            Catalogs catalogs,
+            CatalogLoader catalogLoader,
+            HelmRepoService helmRepoService,
+            @Value("${catalogs.refresh.ms}") long refreshTime) {
+        this.catalogs = catalogs;
+        this.catalogLoader = catalogLoader;
+        this.helmRepoService = helmRepoService;
+        this.refreshTime = refreshTime;
+    }
 
     private void refresh() {
         catalogs.getCatalogs().stream()

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
@@ -37,7 +37,7 @@ public class CatalogRefresher implements ApplicationRunner {
     }
 
     private void refresh() {
-        catalogs.getCatalogs().stream()
+        catalogs.getCatalogs()
                 .forEach(
                         c -> {
                             try {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/LogEventListener.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/LogEventListener.java
@@ -16,9 +16,14 @@ import org.springframework.stereotype.Component;
 @ConditionalOnProperty(name = "event.logging.enabled", havingValue = "true")
 public class LogEventListener {
 
-    @Autowired private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     private static final Logger LOGGER = LoggerFactory.getLogger("onyxia.sh.events");
+
+    @Autowired
+    public LogEventListener(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     @Async
     @EventListener

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/OnyxiaEvent.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/OnyxiaEvent.java
@@ -2,7 +2,5 @@ package fr.insee.onyxia.api.events;
 
 public abstract class OnyxiaEvent {
 
-    public OnyxiaEvent() {}
-
     public abstract String getType();
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/OnyxiaEventPublisher.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/OnyxiaEventPublisher.java
@@ -6,7 +6,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class OnyxiaEventPublisher {
-    @Autowired private ApplicationEventPublisher applicationEventPublisher;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    public OnyxiaEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
 
     public void publishEvent(OnyxiaEvent onyxiaEvent) {
         applicationEventPublisher.publishEvent(onyxiaEvent);

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/DisableCORS.java
@@ -10,7 +10,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class DisableCORS implements WebMvcConfigurer {
 
-    @Autowired private SecurityConfig securityConfig;
+    private final SecurityConfig securityConfig;
+
+    @Autowired
+    public DisableCORS(SecurityConfig securityConfig) {
+        this.securityConfig = securityConfig;
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/OIDCConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/OIDCConfiguration.java
@@ -136,8 +136,7 @@ public class OIDCConfiguration {
     @Scope(scopeName = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.NO)
     public Jwt getUserInfo() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        Jwt jwt = (Jwt) authentication.getPrincipal();
-        return jwt;
+        return (Jwt) authentication.getPrincipal();
     }
 
     @Bean

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/security/OIDCConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/security/OIDCConfiguration.java
@@ -58,7 +58,12 @@ public class OIDCConfiguration {
     @Value("${oidc.clientID}")
     private String clientID;
 
-    @Autowired private HttpRequestUtils httpRequestUtils;
+    private final HttpRequestUtils httpRequestUtils;
+
+    @Autowired
+    public OIDCConfiguration(HttpRequestUtils httpRequestUtils) {
+        this.httpRequestUtils = httpRequestUtils;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -164,10 +169,6 @@ public class OIDCConfiguration {
 
     public void setUsernameClaim(String usernameClaim) {
         this.usernameClaim = usernameClaim;
-    }
-
-    public void setHttpRequestUtils(HttpRequestUtils httpRequestUtils) {
-        this.httpRequestUtils = httpRequestUtils;
     }
 
     public String getGroupsClaim() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/control/xgenerated/XGeneratedProcessor.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/control/xgenerated/XGeneratedProcessor.java
@@ -26,14 +26,13 @@ public class XGeneratedProcessor {
 
     public XGeneratedContext readContext(Pkg pkg) {
         XGeneratedContext xGeneratedContext = new XGeneratedContext();
-        pkg.getConfig().getProperties().getProperties().entrySet().stream()
+        pkg.getConfig()
+                .getProperties()
+                .getProperties()
                 .forEach(
-                        (entry) -> {
-                            xGeneratedReader.readXGenerated(
-                                    Arrays.asList(entry.getKey()),
-                                    entry.getValue(),
-                                    xGeneratedContext);
-                        });
+                        (key, value) ->
+                                xGeneratedReader.readXGenerated(
+                                        List.of(key), value, xGeneratedContext));
         return xGeneratedContext;
     }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/control/xgenerated/XGeneratedProcessor.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/control/xgenerated/XGeneratedProcessor.java
@@ -1,20 +1,28 @@
 package fr.insee.onyxia.api.services.control.xgenerated;
 
 import fr.insee.onyxia.model.catalog.Pkg;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class XGeneratedProcessor {
 
-    @Autowired private XGeneratedReader xGeneratedReader;
+    private final XGeneratedReader xGeneratedReader;
 
-    @Autowired private XGeneratedIterator xGeneratedIterator;
+    private final XGeneratedIterator xGeneratedIterator;
 
-    @Autowired private XGeneratedInjector xGeneratedInjector;
+    private final XGeneratedInjector xGeneratedInjector;
+
+    @Autowired
+    public XGeneratedProcessor(
+            XGeneratedReader xGeneratedReader,
+            XGeneratedIterator xGeneratedIterator,
+            XGeneratedInjector xGeneratedInjector) {
+        this.xGeneratedReader = xGeneratedReader;
+        this.xGeneratedIterator = xGeneratedIterator;
+        this.xGeneratedInjector = xGeneratedInjector;
+    }
 
     public XGeneratedContext readContext(Pkg pkg) {
         XGeneratedContext xGeneratedContext = new XGeneratedContext();
@@ -39,13 +47,5 @@ public class XGeneratedProcessor {
     public void injectIntoContext(
             Map<String, Object> target, Map<String, String> xGeneratedValues) {
         xGeneratedInjector.injectIntoContext(target, xGeneratedValues);
-    }
-
-    public XGeneratedReader getxGeneratedReader() {
-        return xGeneratedReader;
-    }
-
-    public void setxGeneratedReader(XGeneratedReader xGeneratedReader) {
-        this.xGeneratedReader = xGeneratedReader;
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/CatalogServiceImpl.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/CatalogServiceImpl.java
@@ -12,7 +12,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class CatalogServiceImpl implements CatalogService {
 
-    @Autowired private Catalogs catalogs;
+    private final Catalogs catalogs;
+
+    @Autowired
+    public CatalogServiceImpl(Catalogs catalogs) {
+        this.catalogs = catalogs;
+    }
 
     @Override
     public Catalogs getCatalogs() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -55,25 +55,42 @@ public class HelmAppsService implements AppsService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HelmAppsService.class);
 
+    private final ObjectMapper mapperHelm;
+
+    private final KubernetesService kubernetesService;
+
+    private final List<AdmissionControllerHelm> admissionControllers;
+
+    private final FastDateFormat helmDateFormat = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss");
+    private final KubernetesClientProvider kubernetesClientProvider;
+
+    private final HelmClientProvider helmClientProvider;
+
+    private final XGeneratedProcessor xGeneratedProcessor;
+
+    private final UrlGenerator urlGenerator;
+
+    final OnyxiaEventPublisher onyxiaEventPublisher;
+
     @Autowired
-    @Qualifier("helm")
-    ObjectMapper mapperHelm;
-
-    @Autowired private KubernetesService kubernetesService;
-
-    @Autowired(required = false)
-    private List<AdmissionControllerHelm> admissionControllers = new ArrayList<>();
-
-    private FastDateFormat helmDateFormat = FastDateFormat.getInstance("yyyy-MM-dd HH:mm:ss");
-    @Autowired private KubernetesClientProvider kubernetesClientProvider;
-
-    @Autowired private HelmClientProvider helmClientProvider;
-
-    @Autowired private XGeneratedProcessor xGeneratedProcessor;
-
-    @Autowired private UrlGenerator urlGenerator;
-
-    @Autowired OnyxiaEventPublisher onyxiaEventPublisher;
+    public HelmAppsService(
+            @Qualifier("helm") ObjectMapper mapperHelm,
+            KubernetesService kubernetesService,
+            List<AdmissionControllerHelm> admissionControllers,
+            KubernetesClientProvider kubernetesClientProvider,
+            HelmClientProvider helmClientProvider,
+            XGeneratedProcessor xGeneratedProcessor,
+            UrlGenerator urlGenerator,
+            OnyxiaEventPublisher onyxiaEventPublisher) {
+        this.mapperHelm = mapperHelm;
+        this.kubernetesService = kubernetesService;
+        this.admissionControllers = admissionControllers;
+        this.kubernetesClientProvider = kubernetesClientProvider;
+        this.helmClientProvider = helmClientProvider;
+        this.xGeneratedProcessor = xGeneratedProcessor;
+        this.urlGenerator = urlGenerator;
+        this.onyxiaEventPublisher = onyxiaEventPublisher;
+    }
 
     private HelmConfiguration getHelmConfiguration(Region region, User user) {
         return helmClientProvider.getConfiguration(region, user);

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/kubernetes/KubernetesService.java
@@ -29,10 +29,18 @@ import org.springframework.stereotype.Service;
 @Service
 public class KubernetesService {
 
-    @Autowired private KubernetesClientProvider kubernetesClientProvider;
+    private final KubernetesClientProvider kubernetesClientProvider;
 
-    @Autowired OnyxiaEventPublisher onyxiaEventPublisher;
+    final OnyxiaEventPublisher onyxiaEventPublisher;
     private static final Logger LOGGER = LoggerFactory.getLogger(KubernetesService.class);
+
+    @Autowired
+    public KubernetesService(
+            KubernetesClientProvider kubernetesClientProvider,
+            OnyxiaEventPublisher onyxiaEventPublisher) {
+        this.kubernetesClientProvider = kubernetesClientProvider;
+        this.onyxiaEventPublisher = onyxiaEventPublisher;
+    }
 
     public String createDefaultNamespace(Region region, Owner owner) {
         final String namespaceId = getDefaultNamespace(region, owner);

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/utils/HttpRequestUtils.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/utils/HttpRequestUtils.java
@@ -24,9 +24,8 @@ public class HttpRequestUtils {
 
         for (String header : IP_HEADER_CANDIDATES) {
             String ipList = request.getHeader(header);
-            if (ipList != null && ipList.length() != 0 && !"unknown".equalsIgnoreCase(ipList)) {
-                String ip = ipList.split(",")[0];
-                return ip;
+            if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
+                return ipList.split(",")[0];
             }
         }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/user/OnyxiaUserProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/user/OnyxiaUserProvider.java
@@ -35,7 +35,9 @@ public class OnyxiaUserProvider {
         Pattern includedGroupPattern = getPrecompiledIncludedGroupPattern(region);
 
         if (!region.getServices().isSingleNamespace()) {
-            userProvider.getUser(region).getGroups().stream()
+            userProvider
+                    .getUser(region)
+                    .getGroups()
                     .forEach(
                             group -> {
                                 String projectBaseName =

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/user/OnyxiaUserProvider.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/user/OnyxiaUserProvider.java
@@ -14,10 +14,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class OnyxiaUserProvider {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(OnyxiaUserProvider.class);
+
     Pattern rfc1123Pattern = Pattern.compile("[a-z0-9]([-a-z0-9]*[a-z0-9])?");
-    @Autowired private UserProvider userProvider;
-    @Autowired private KubernetesService kubernetesService; // TODO : cleanup
-    private Logger LOGGER = LoggerFactory.getLogger(OnyxiaUserProvider.class);
+    private final UserProvider userProvider;
+    private final KubernetesService kubernetesService; // TODO : cleanup
+
+    @Autowired
+    public OnyxiaUserProvider(UserProvider userProvider, KubernetesService kubernetesService) {
+        this.userProvider = userProvider;
+        this.kubernetesService = kubernetesService;
+    }
 
     public OnyxiaUser getUser(Region region) {
         OnyxiaUser user = new OnyxiaUser(userProvider.getUser(region));


### PR DESCRIPTION
As described in sonarcloud (rule `java:S6813`)

> Dependency injection frameworks such as Spring support dependency injection by using annotations such as @Inject and @Autowired. These annotations can be used to inject beans via constructor, setter, and field injection.
> 
> Generally speaking, field injection is discouraged. It allows the creation of objects in an invalid state and makes testing more difficult. The dependencies are not explicit when instantiating a class that uses field injection.
> 
> In addition, field injection is not compatible with final fields. Keeping dependencies immutable where possible makes the code easier to understand, easing development and maintenance.
> 
> Finally, because values are injected into fields after the object has been constructed, they cannot be used to initialize other non-injected fields inline.
> 
> This rule raises an issue when the @Autowired or @Inject annotations are used on a field.