### PR TITLE
Revert org.apache.commons:commons-compress v1.26.0

### DIFF
--- a/onyxia-api/pom.xml
+++ b/onyxia-api/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.26.0</version>
+            <version>1.25.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This reverts commit 96b8f2a1e50a7e2fcc52bb7c485e9a0522eeeede due to a possible regression in packages uncompress