### PR TITLE
Cleanup events

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -26,7 +26,6 @@ import fr.insee.onyxia.model.dto.ServicesListing;
 import fr.insee.onyxia.model.project.Project;
 import fr.insee.onyxia.model.region.Region;
 import fr.insee.onyxia.model.service.*;
-import io.fabric8.kubernetes.api.model.EventList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watcher;
 import io.github.inseefrlab.helmwrapper.configuration.HelmConfiguration;
@@ -484,34 +483,6 @@ public class HelmAppsService implements AppsService {
                                     return currentTask;
                                 })
                         .collect(Collectors.toList()));
-
-        EventList eventList = client.v1().events().inNamespace(release.getNamespace()).list();
-        List<Event> events =
-                eventList.getItems().stream()
-                        .filter(
-                                event ->
-                                        event.getInvolvedObject() != null
-                                                && event.getInvolvedObject().getName() != null
-                                                && event.getInvolvedObject()
-                                                        .getName()
-                                                        .contains(release.getName()))
-                        .map(
-                                event -> {
-                                    Event newEvent = new Event();
-                                    newEvent.setMessage(event.getMessage());
-                                    try {
-                                        // TODO : use kubernetes time format instead of helm
-                                        newEvent.setTimestamp(
-                                                helmDateFormat
-                                                        .parse(event.getEventTime().getTime())
-                                                        .getTime());
-                                    } catch (Exception e) {
-
-                                    }
-                                    return newEvent;
-                                })
-                        .collect(Collectors.toList());
-        service.setEvents(events);
 
         return service;
     }

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/service/Service.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/service/Service.java
@@ -44,9 +44,6 @@ public class Service {
     @Schema(description = "Task represents pods running. This should be re-ingeneer in v1.0")
     private List<Task> tasks = new ArrayList<>();
 
-    @Schema(description = "This should be re-ingeneer in v1.0")
-    private List<Event> events = new ArrayList<>();
-
     @Schema(description = "This should be removed in v1.0")
     private String subtitle;
 
@@ -179,14 +176,6 @@ public class Service {
 
     public void setSubtitle(String subtitle) {
         this.subtitle = subtitle;
-    }
-
-    public List<Event> getEvents() {
-        return events;
-    }
-
-    public void setEvents(List<Event> events) {
-        this.events = events;
     }
 
     public List<String> getInternalUrls() {


### PR DESCRIPTION
Now that events have been moved to namespace level (see #405 ), we cleanup the events at release level which was bugged (see #381 and never used by the UI anyway).  

Fix #381 
