### PR TITLE
Fixes two reliability issues in CompatibilityChecks and CatalogRefresher (from SonarCloud)

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecks.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecks.java
@@ -35,6 +35,11 @@ public class CompatibilityChecks {
     public void checkHelm() {
         try {
             LOGGER.info("Using helm {}", helmVersionService.getVersion());
+        } catch (InterruptedException e) {
+            // Restore the interrupted status
+            Thread.currentThread().interrupt();
+            LOGGER.error("Thread was interrupted while determining helm version", e);
+            // Handle interruption-specific logic if needed
         } catch (Exception e) {
             LOGGER.error("Could not determine helm version", e);
             System.exit(0);

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogRefresher.java
@@ -55,7 +55,10 @@ public class CatalogRefresher implements ApplicationRunner {
 
         try {
             helmRepoService.repoUpdate();
-        } catch (InterruptedException | TimeoutException | IOException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.warn("Thread was interrupted during repo update", e);
+        } catch (TimeoutException | IOException e) {
             LOGGER.warn("Exception occurred", e);
         }
     }

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecksTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecksTest.java
@@ -18,8 +18,14 @@ class CompatibilityChecksTest {
 
     @InjectMocks private CompatibilityChecks compatibilityChecks;
 
+    private boolean exitCalled;
+
     @BeforeEach
-    public void setUp() {}
+    void setUp() {
+        exitCalled = false;
+        compatibilityChecks =
+                new CompatibilityChecks(null, null, helmVersionService, () -> exitCalled = true);
+    }
 
     @Test
     void testCheckHelmHandlesInterruptedException() throws Exception {
@@ -38,13 +44,9 @@ class CompatibilityChecksTest {
     void testCheckHelmHandlesGenericException() throws Exception {
         doThrow(new RuntimeException("Some other exception")).when(helmVersionService).getVersion();
 
-        try {
-            compatibilityChecks.checkHelm();
-        } catch (Exception e) {
-            // This shouldn't be reached due to System.exit(0), but we want to ensure the LOGGER
-            // call is made
-            verify(helmVersionService).getVersion();
-            assert (false); // Fail the test if an exception is thrown
-        }
+        compatibilityChecks.checkHelm();
+
+        verify(helmVersionService).getVersion();
+        assert (exitCalled); // Check that the exit handler was called
     }
 }

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecksTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecksTest.java
@@ -1,0 +1,50 @@
+package fr.insee.onyxia.api.configuration.checks;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import io.github.inseefrlab.helmwrapper.service.HelmVersionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CompatibilityChecksTest {
+
+    @Mock private HelmVersionService helmVersionService;
+
+    @InjectMocks private CompatibilityChecks compatibilityChecks;
+
+    @BeforeEach
+    public void setUp() {}
+
+    @Test
+    public void testCheckHelmHandlesInterruptedException() throws Exception {
+        doThrow(new InterruptedException("Thread was interrupted"))
+                .when(helmVersionService)
+                .getVersion();
+
+        compatibilityChecks.checkHelm();
+
+        verify(helmVersionService).getVersion();
+        // Ensure that the current thread's interrupted status is set
+        assert (Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    public void testCheckHelmHandlesGenericException() throws Exception {
+        doThrow(new RuntimeException("Some other exception")).when(helmVersionService).getVersion();
+
+        try {
+            compatibilityChecks.checkHelm();
+        } catch (Exception e) {
+            // This shouldn't be reached due to System.exit(0), but we want to ensure the LOGGER
+            // call is made
+            verify(helmVersionService).getVersion();
+            assert (false); // Fail the test if an exception is thrown
+        }
+    }
+}

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecksTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/checks/CompatibilityChecksTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class CompatibilityChecksTest {
+class CompatibilityChecksTest {
 
     @Mock private HelmVersionService helmVersionService;
 
@@ -22,7 +22,7 @@ public class CompatibilityChecksTest {
     public void setUp() {}
 
     @Test
-    public void testCheckHelmHandlesInterruptedException() throws Exception {
+    void testCheckHelmHandlesInterruptedException() throws Exception {
         doThrow(new InterruptedException("Thread was interrupted"))
                 .when(helmVersionService)
                 .getVersion();
@@ -35,7 +35,7 @@ public class CompatibilityChecksTest {
     }
 
     @Test
-    public void testCheckHelmHandlesGenericException() throws Exception {
+    void testCheckHelmHandlesGenericException() throws Exception {
         doThrow(new RuntimeException("Some other exception")).when(helmVersionService).getVersion();
 
         try {

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogRefresherTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogRefresherTest.java
@@ -1,0 +1,59 @@
+package fr.insee.onyxia.api.dao.universe;
+
+import static org.mockito.Mockito.*;
+
+import fr.insee.onyxia.api.configuration.Catalogs;
+import io.github.inseefrlab.helmwrapper.service.HelmRepoService;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.ApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+public class CatalogRefresherTest {
+
+    @Mock private Catalogs catalogs;
+
+    @Mock private CatalogLoader catalogLoader;
+
+    @Mock private HelmRepoService helmRepoService;
+
+    @Mock private ApplicationArguments applicationArguments;
+
+    private CatalogRefresher catalogRefresher;
+
+    @BeforeEach
+    public void setUp() {
+        catalogRefresher = new CatalogRefresher(catalogs, catalogLoader, helmRepoService, 1000L);
+    }
+
+    @Test
+    public void testRefreshHandlesInterruptedException() throws Exception {
+        doThrow(new InterruptedException("Thread was interrupted"))
+                .when(helmRepoService)
+                .repoUpdate();
+
+        catalogRefresher.run(applicationArguments);
+
+        verify(helmRepoService).repoUpdate();
+        // Ensure that the current thread's interrupted status is set
+        assert (Thread.currentThread().isInterrupted());
+    }
+
+    @Test
+    public void testRefreshHandlesTimeoutAndIOException() throws Exception {
+        doThrow(new TimeoutException("Timeout")).when(helmRepoService).repoUpdate();
+
+        catalogRefresher.run(applicationArguments);
+        verify(helmRepoService).repoUpdate();
+
+        doThrow(new IOException("IO Exception")).when(helmRepoService).repoUpdate();
+
+        catalogRefresher.run(applicationArguments);
+        verify(helmRepoService, times(2)).repoUpdate();
+    }
+}

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogRefresherTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogRefresherTest.java
@@ -14,7 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.ApplicationArguments;
 
 @ExtendWith(MockitoExtension.class)
-public class CatalogRefresherTest {
+class CatalogRefresherTest {
 
     @Mock private Catalogs catalogs;
 
@@ -32,7 +32,7 @@ public class CatalogRefresherTest {
     }
 
     @Test
-    public void testRefreshHandlesInterruptedException() throws Exception {
+    void testRefreshHandlesInterruptedException() throws Exception {
         doThrow(new InterruptedException("Thread was interrupted"))
                 .when(helmRepoService)
                 .repoUpdate();
@@ -45,7 +45,7 @@ public class CatalogRefresherTest {
     }
 
     @Test
-    public void testRefreshHandlesTimeoutAndIOException() throws Exception {
+    void testRefreshHandlesTimeoutAndIOException() throws Exception {
         doThrow(new TimeoutException("Timeout")).when(helmRepoService).repoUpdate();
 
         catalogRefresher.run(applicationArguments);


### PR DESCRIPTION
Fix: Handle InterruptedException correctly in CompatibilityChecks and CatalogRefresher

- CompatibilityChecks:
  - Catch InterruptedException separately, re-interrupt the thread, and log the interruption.
  - Added CompatibilityChecksTest to verify proper handling of InterruptedException and other exceptions.

- CatalogRefresher:
  - Catch InterruptedException in refresh method, re-interrupt the thread, and log the interruption.
  - Added CatalogRefresherTest to verify proper handling of InterruptedException, TimeoutException, and IOException.

Rated as medium issues on reliability on SonarCloud, and a nice excuse for adding more tests. 😄 