### PR TITLE
Fix for special helm commands (version check + repo add)

### DIFF
--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmRepoService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmRepoService.java
@@ -39,7 +39,7 @@ public class HelmRepoService {
                             "--ca-file " + System.getenv("CACERTS_DIR") + "/" + caFile + " ");
         }
         command = command.concat(nomRepo + " " + url);
-        return Command.execute(command).getOutput().getString();
+        return Command.execute(null, command, true).getOutput().getString();
     }
 
     public void repoUpdate() throws InterruptedException, TimeoutException, IOException {

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmVersionService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmVersionService.java
@@ -10,7 +10,8 @@ public class HelmVersionService {
 
     public String getVersion()
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        return Command.executeAndGetResponseAsRaw("helm version --template={{.Version}}")
+        return Command.executeAndGetResponseAsRaw(
+                        null, "helm version --template={{.Version}}", true)
                 .getOutput()
                 .getString(StandardCharsets.UTF_8.name());
     }

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
@@ -38,9 +38,11 @@ public class Command {
     }
 
     public static ProcessResult executeAndGetResponseAsJson(
-            HelmConfiguration helmConfiguration, String command)
+            HelmConfiguration helmConfiguration, String command, boolean bypassCommandValidation)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        validateCommand(command);
+        if (!bypassCommandValidation) {
+            validateCommand(command);
+        }
         return getProcessExecutor()
                 .environment(getEnv(helmConfiguration))
                 .commandSplit(buildSecureCommand(command, helmConfiguration) + " --output json")
@@ -49,8 +51,7 @@ public class Command {
 
     public static ProcessResult executeAndGetResponseAsJson(String command)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        validateCommand(command);
-        return executeAndGetResponseAsJson(null, command);
+        return executeAndGetResponseAsJson(null, command, false);
     }
 
     public static ProcessResult executeAndGetResponseAsRaw(
@@ -78,7 +79,15 @@ public class Command {
 
     public static ProcessResult execute(HelmConfiguration helmConfiguration, String command)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        validateCommand(command);
+        return execute(helmConfiguration, command, false);
+    }
+
+    public static ProcessResult execute(
+            HelmConfiguration helmConfiguration, String command, boolean bypassCommandValidation)
+            throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
+        if (!bypassCommandValidation) {
+            validateCommand(command);
+        }
         return getProcessExecutor()
                 .environment(getEnv(helmConfiguration))
                 .commandSplit(buildSecureCommand(command, helmConfiguration))
@@ -87,7 +96,6 @@ public class Command {
 
     public static ProcessResult execute(String command)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        validateCommand(command);
         return execute(null, command);
     }
 

--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/utils/Command.java
@@ -56,7 +56,15 @@ public class Command {
     public static ProcessResult executeAndGetResponseAsRaw(
             HelmConfiguration helmConfiguration, String command)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        validateCommand(command);
+        return executeAndGetResponseAsRaw(helmConfiguration, command, false);
+    }
+
+    public static ProcessResult executeAndGetResponseAsRaw(
+            HelmConfiguration helmConfiguration, String command, boolean bypassCommandValidation)
+            throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
+        if (!bypassCommandValidation) {
+            validateCommand(command);
+        }
         return getProcessExecutor()
                 .environment(getEnv(helmConfiguration))
                 .commandSplit(buildSecureCommand(command, helmConfiguration))
@@ -65,7 +73,6 @@ public class Command {
 
     public static ProcessResult executeAndGetResponseAsRaw(String command)
             throws InvalidExitValueException, IOException, InterruptedException, TimeoutException {
-        validateCommand(command);
         return executeAndGetResponseAsRaw(null, command);
     }
 


### PR DESCRIPTION
#441 introduced a systematic verification of each command sent to helm.  
This is good but the initial helm version check and helm repo add uses special characters that are now flagged by this verification system.  
This PR introduces a bypass in the helm-wrapper API to allow special commands to be whitelisted