### PR TITLE
Implement support for specifying container when getting logs

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -298,10 +298,16 @@ public class MyLabController {
             @Parameter(hidden = true) Region region,
             @Parameter(hidden = true) Project project,
             @RequestParam("serviceId") String serviceId,
-            @RequestParam("taskId") String taskId) {
+            @RequestParam("taskId") String taskId,
+            @RequestParam("containerId") Optional<String> containerId) {
         if (Service.ServiceType.KUBERNETES.equals(region.getServices().getType())) {
             return helmAppsService.getLogs(
-                    region, project, userProvider.getUser(region), serviceId, taskId);
+                    region,
+                    project,
+                    userProvider.getUser(region),
+                    serviceId,
+                    taskId,
+                    containerId.orElse(null));
         }
         return null;
     }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
@@ -49,7 +49,13 @@ public interface AppsService {
     UninstallService destroyService(
             Region region, Project project, User user, String path, boolean bulk) throws Exception;
 
-    String getLogs(Region region, Project project, User user, String serviceId, String taskId);
+    String getLogs(
+            Region region,
+            Project project,
+            User user,
+            String serviceId,
+            String taskId,
+            String containerId);
 
     Watch getEvents(Region region, Project project, User user, Watcher<Event> watcher)
             throws HelmInstallService.MultipleServiceFound, ParseException;

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -198,13 +198,19 @@ public class HelmAppsService implements AppsService {
 
     @Override
     public String getLogs(
-            Region region, Project project, User user, String serviceId, String taskId) {
+            Region region,
+            Project project,
+            User user,
+            String serviceId,
+            String taskId,
+            String containerId) {
         KubernetesClient client = kubernetesClientProvider.getUserClient(region, user);
         return client.pods()
                 .inNamespace(
                         kubernetesService.determineNamespaceAndCreateIfNeeded(
                                 region, project, user))
                 .withName(taskId)
+                .inContainer(containerId)
                 .getLog();
     }
 


### PR DESCRIPTION
If a pod have more than one container the current call will fail. This commit fix that issue, while preserving backward compatibility in the api by making the container id parameter optional.
The get logs call will behave as before if container id is null or empty.

This change may not make sense if there is no plan to implement support for this in the frontend (other changes may be required by api for this, such as returning which containers the pod contain).
If that is the case, feel free to close this PR