### PR TITLE
Add support for annotations in helm chart

### DIFF
--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/helm/Chart.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/helm/Chart.java
@@ -87,6 +87,10 @@ public class Chart extends Pkg {
     @JsonProperty("version")
     private String version;
 
+    @Schema(description = "")
+    @JsonProperty("annotations")
+    private Map<String, String> annotations;
+
     @JsonIgnore private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
     @Schema(description = "")
@@ -241,6 +245,16 @@ public class Chart extends Pkg {
     @JsonProperty("version")
     public void setVersion(String version) {
         this.version = version;
+    }
+
+    @JsonProperty("annotations")
+    public Map<String, String> getAnnotations() {
+        return annotations;
+    }
+
+    @JsonProperty("annotations")
+    public void setAnnotations(Map<String, String> annotations) {
+        this.annotations = annotations;
     }
 
     @JsonProperty("defaultValues")


### PR DESCRIPTION
The Chart.yaml follows a strict schema where additional fields are not allowed (defined by helm). The recommended approach is to add custom metadata in annotations. One example of this usage can be seen in the apache chart here: https://github.com/bitnami/charts/blob/airflow/19.0.5/bitnami/airflow/Chart.yaml

This change introduce support for the annotations field, and expose it such that the UI can use it as wanted.

After:
Onxyia-api exposes the annotations field as a map<string, Object>
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/83eac863-1653-42f1-ba10-76147529c53a">


For more information about the chart.yaml and conventions, see: https://helm.sh/docs/topics/charts/#the-chartyaml-file

Resolves #479



