### PR TITLE
Add support for specifying timeout in catalogs

### DIFF
--- a/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
+++ b/helm-wrapper/src/main/java/io/github/inseefrlab/helmwrapper/service/HelmInstallService.java
@@ -42,6 +42,7 @@ public class HelmInstallService {
             String version,
             boolean dryRun,
             final boolean skipTlsVerify,
+            String timeout,
             String caFile)
             throws InvalidExitValueException,
                     IOException,
@@ -58,6 +59,7 @@ public class HelmInstallService {
                 null,
                 Map.of("global.suspend", "false"),
                 skipTlsVerify,
+                timeout,
                 caFile,
                 true);
     }
@@ -70,6 +72,7 @@ public class HelmInstallService {
             String version,
             boolean dryRun,
             final boolean skipTlsVerify,
+            String timeout,
             String caFile)
             throws InvalidExitValueException,
                     IOException,
@@ -86,6 +89,7 @@ public class HelmInstallService {
                 null,
                 Map.of("global.suspend", "true"),
                 skipTlsVerify,
+                timeout,
                 caFile,
                 true);
     }
@@ -100,6 +104,7 @@ public class HelmInstallService {
             File values,
             Map<String, String> env,
             final boolean skipTlsVerify,
+            String timeout,
             String caFile)
             throws InvalidExitValueException,
                     IOException,
@@ -116,6 +121,7 @@ public class HelmInstallService {
                 values,
                 env,
                 skipTlsVerify,
+                timeout,
                 caFile,
                 false);
     }
@@ -130,6 +136,7 @@ public class HelmInstallService {
             File values,
             Map<String, String> env,
             final boolean skipTlsVerify,
+            String timeout,
             String caFile,
             boolean reuseValues)
             throws InvalidExitValueException,
@@ -138,6 +145,11 @@ public class HelmInstallService {
                     TimeoutException,
                     IllegalArgumentException {
         StringBuilder command = new StringBuilder("helm upgrade --install --history-max 0 ");
+
+        if (timeout != null) {
+            command.append("--timeout " + timeout + " ");
+        }
+
         if (skipTlsVerify) {
             command.append("--insecure-skip-tls-verify ");
         } else if (caFile != null) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
@@ -54,6 +54,9 @@ public class CatalogWrapper {
     @Schema(description = "Skip tls certificate checks for the repository")
     private boolean skipTlsVerify;
 
+    @Schema(description = "value to wait for helm command to complete")
+    private String timeout;
+
     @Schema(description = "Verify certificates of HTTPS-enabled servers using this CA bundle")
     private String caFile;
 
@@ -197,6 +200,14 @@ public class CatalogWrapper {
 
     public void setSkipTlsVerify(boolean skipTlsVerify) {
         this.skipTlsVerify = skipTlsVerify;
+    }
+
+    public String getTimeout() {
+        return timeout;
+    }
+
+    public void setTimeout(String timeout) {
+        this.timeout = timeout;
     }
 
     public String getCaFile() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfiguration.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfiguration.java
@@ -29,7 +29,7 @@ public class CatalogsConfiguration {
 
     private List<CatalogWrapper> resolvedCatalogs;
 
-    private ObjectMapper mapper;
+    private final ObjectMapper mapper;
 
     @Autowired
     public CatalogsConfiguration(ObjectMapper mapper) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -248,6 +248,7 @@ public class MyLabController {
                         user,
                         serviceId,
                         catalog.get().getSkipTlsVerify(),
+                        catalog.get().getTimeout(),
                         catalog.get().getCaFile(),
                         false);
             } else {
@@ -260,6 +261,7 @@ public class MyLabController {
                         user,
                         serviceId,
                         catalog.get().getSkipTlsVerify(),
+                        catalog.get().getTimeout(),
                         catalog.get().getCaFile(),
                         false);
             }
@@ -473,10 +475,20 @@ public class MyLabController {
 
         boolean skipTlsVerify = catalog.getSkipTlsVerify();
         String caFile = catalog.getCaFile();
+        String timeout = catalog.getTimeout();
         Map<String, Object> fusion = new HashMap<>();
         fusion.putAll((Map<String, Object>) requestDTO.getOptions());
         return helmAppsService.installApp(
-                region, project, requestDTO, catalogId, pkg, user, fusion, skipTlsVerify, caFile);
+                region,
+                project,
+                requestDTO,
+                catalogId,
+                pkg,
+                user,
+                fusion,
+                skipTlsVerify,
+                timeout,
+                caFile);
     }
 
     public static class SuspendOrResumeRequestDTO {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/AppsService.java
@@ -40,6 +40,7 @@ public interface AppsService {
             User user,
             Map<String, Object> fusion,
             final boolean skipTlsVerify,
+            String timeout,
             final String caFile)
             throws Exception;
 
@@ -69,6 +70,7 @@ public interface AppsService {
             User user,
             String serviceId,
             boolean skipTlsVerify,
+            String timeout,
             String caFile,
             boolean dryRun)
             throws IOException, InterruptedException, TimeoutException;
@@ -82,6 +84,7 @@ public interface AppsService {
             User user,
             String serviceId,
             boolean skipTlsVerify,
+            String timeout,
             String caFile,
             boolean dryRun)
             throws IOException, InterruptedException, TimeoutException;

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/impl/HelmAppsService.java
@@ -103,6 +103,7 @@ public class HelmAppsService implements AppsService {
             User user,
             Map<String, Object> fusion,
             final boolean skipTlsVerify,
+            String timeout,
             final String caFile)
             throws IOException, TimeoutException, InterruptedException {
 
@@ -123,6 +124,7 @@ public class HelmAppsService implements AppsService {
                                     values,
                                     null,
                                     skipTlsVerify,
+                                    timeout,
                                     caFile);
             InstallServiceEvent installServiceEvent =
                     new InstallServiceEvent(
@@ -410,6 +412,7 @@ public class HelmAppsService implements AppsService {
             User user,
             String serviceId,
             boolean skipTlsVerify,
+            String timeout,
             String caFile,
             boolean dryRun)
             throws IOException, InterruptedException, TimeoutException {
@@ -422,6 +425,7 @@ public class HelmAppsService implements AppsService {
                 user,
                 serviceId,
                 skipTlsVerify,
+                timeout,
                 caFile,
                 dryRun,
                 true);
@@ -437,6 +441,7 @@ public class HelmAppsService implements AppsService {
             User user,
             String serviceId,
             boolean skipTlsVerify,
+            String timeout,
             String caFile,
             boolean dryRun)
             throws IOException, InterruptedException, TimeoutException {
@@ -449,6 +454,7 @@ public class HelmAppsService implements AppsService {
                 user,
                 serviceId,
                 skipTlsVerify,
+                timeout,
                 caFile,
                 dryRun,
                 false);
@@ -463,6 +469,7 @@ public class HelmAppsService implements AppsService {
             User user,
             String serviceId,
             boolean skipTlsVerify,
+            String timeout,
             String caFile,
             boolean dryRun,
             boolean suspend)
@@ -479,6 +486,7 @@ public class HelmAppsService implements AppsService {
                             version,
                             dryRun,
                             skipTlsVerify,
+                            timeout,
                             caFile);
         } else {
             getHelmInstallService()
@@ -490,6 +498,7 @@ public class HelmAppsService implements AppsService {
                             version,
                             dryRun,
                             skipTlsVerify,
+                            timeout,
                             caFile);
         }
         SuspendResumeServiceEvent event =

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfigurationTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/configuration/properties/CatalogsConfigurationTest.java
@@ -1,0 +1,27 @@
+package fr.insee.onyxia.api.configuration.properties;
+
+import static fr.insee.onyxia.api.util.TestUtils.getClassPathResource;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fr.insee.onyxia.api.configuration.CatalogWrapper;
+import fr.insee.onyxia.api.configuration.CustomObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CatalogsConfigurationTest {
+
+    @Test
+    void shouldBeAbleToParseCatalogWithTimeout() throws Exception {
+        ObjectMapper objectMapper = new CustomObjectMapper().objectMapper();
+        String catalogWrapper = getClassPathResource("catalog-loader-test/catalog-wrapper.json5");
+
+        CatalogsConfiguration catalogsConfiguration = new CatalogsConfiguration(objectMapper);
+        catalogsConfiguration.setCatalogs(catalogWrapper);
+        catalogsConfiguration.load();
+        List<CatalogWrapper> resolvedCatalogs = catalogsConfiguration.getResolvedCatalogs();
+
+        assertEquals(1, resolvedCatalogs.size());
+        assertEquals("10m", resolvedCatalogs.getFirst().getTimeout());
+    }
+}

--- a/onyxia-api/src/test/resources/catalog-loader-test/catalog-wrapper.json5
+++ b/onyxia-api/src/test/resources/catalog-loader-test/catalog-wrapper.json5
@@ -1,6 +1,5 @@
-// This file is a json5-file, which onyxia-api should be able to parse
-{
-  "catalogs": [
+// This file is a json5-file, which onyxia-api should be able to parse to a CatalogWrapper list
+[
     {
       "id": "ide",
       "name": "IDE",
@@ -32,5 +31,4 @@
         }
       ]
     },
-  ],
-}
+]


### PR DESCRIPTION
P.t. every chart uses the default 5 min helm timeout. We have however encountered that some chart may use more than these 5 minutes to get installed. This can be due to a combination of scale up + pulling images + mounting buckets. Therefore we need a way to configure timeout.

This PR propose specifying the timeout during install on the catalog:

<img width="199" alt="image" src="https://github.com/user-attachments/assets/e9483cde-cd8f-48a2-96ab-17c5262cd00e">

Originally I wanted to implement this as a `java.time.Duration`, but due to some issues with jackson I ended up using `String`
