### PR TITLE
Add a runtime check for V3 migration

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/V3Checks.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/V3Checks.java
@@ -19,22 +19,25 @@ public class V3Checks {
 
     @Autowired
     public V3Checks(RegionsConfiguration regionsConfiguration) {
-        this(regionsConfiguration,  () -> System.exit(0));
+        this(regionsConfiguration, () -> System.exit(0));
     }
 
-    public V3Checks(
-            RegionsConfiguration regionsConfiguration, Runnable exitHandler) {
+    public V3Checks(RegionsConfiguration regionsConfiguration, Runnable exitHandler) {
         this.regionsConfiguration = regionsConfiguration;
         this.exitHandler = exitHandler;
     }
 
     @EventListener(ContextRefreshedEvent.class)
     public void checkDefaultConfigurationIsNoLongerSupported() {
-        regionsConfiguration.getResolvedRegions().forEach(region -> {
-           if (region.getServices().getDefaultConfiguration() != null) {
-               LOGGER.error("FATAL : Setting defaultConfiguration in region is no longer supported and has been replaced by JSONSchema support. See migration guide at https://docs.onyxia.sh/admin-doc/migration-guides/v8-greater-than-v9");
-               exitHandler.run();
-           }
-        });
+        regionsConfiguration
+                .getResolvedRegions()
+                .forEach(
+                        region -> {
+                            if (region.getServices().getDefaultConfiguration() != null) {
+                                LOGGER.error(
+                                        "FATAL : Setting defaultConfiguration in region is no longer supported and has been replaced by JSONSchema support. See migration guide at https://docs.onyxia.sh/admin-doc/migration-guides/v8-greater-than-v9");
+                                exitHandler.run();
+                            }
+                        });
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/V3Checks.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/checks/V3Checks.java
@@ -1,0 +1,40 @@
+package fr.insee.onyxia.api.configuration.checks;
+
+import fr.insee.onyxia.api.configuration.properties.RegionsConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+
+@Configuration
+public class V3Checks {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(V3Checks.class);
+
+    private final RegionsConfiguration regionsConfiguration;
+
+    private final Runnable exitHandler;
+
+    @Autowired
+    public V3Checks(RegionsConfiguration regionsConfiguration) {
+        this(regionsConfiguration,  () -> System.exit(0));
+    }
+
+    public V3Checks(
+            RegionsConfiguration regionsConfiguration, Runnable exitHandler) {
+        this.regionsConfiguration = regionsConfiguration;
+        this.exitHandler = exitHandler;
+    }
+
+    @EventListener(ContextRefreshedEvent.class)
+    public void checkDefaultConfigurationIsNoLongerSupported() {
+        regionsConfiguration.getResolvedRegions().forEach(region -> {
+           if (region.getServices().getDefaultConfiguration() != null) {
+               LOGGER.error("FATAL : Setting defaultConfiguration in region is no longer supported and has been replaced by JSONSchema support. See migration guide at https://docs.onyxia.sh/admin-doc/migration-guides/v8-greater-than-v9");
+               exitHandler.run();
+           }
+        });
+    }
+}

--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -49,10 +49,6 @@
             "count/pods": "52"
           }
         },
-        "defaultConfiguration": {
-          "IPProtection": false,
-          "networkPolicy": false
-        },
         "expose": {
           "domain": "fakedomain.kub.example.com",
           "ingress": true,

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import fr.insee.onyxia.model.service.quota.Quota;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -207,6 +206,7 @@ public class Region {
          * @See V3Checks
          */
         private Object defaultConfiguration = null;
+
         private K8sPublicEndpoint k8sPublicEndpoint = new K8sPublicEndpoint();
 
         private NamespaceAnnotationsDynamic namespaceAnnotationsDynamic =

--- a/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
+++ b/onyxia-model/src/main/java/fr/insee/onyxia/model/region/Region.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import fr.insee.onyxia.model.service.quota.Quota;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -199,6 +200,13 @@ public class Region {
         private Monitoring monitoring;
         private String allowedURIPattern = "^https://";
         private Quotas quotas = new Quotas();
+
+        /***
+         * @Deprecated since v3
+         * Should no longer be used. If used, a check will fail at startup and crash the app.
+         * @See V3Checks
+         */
+        private Object defaultConfiguration = null;
         private K8sPublicEndpoint k8sPublicEndpoint = new K8sPublicEndpoint();
 
         private NamespaceAnnotationsDynamic namespaceAnnotationsDynamic =
@@ -210,6 +218,14 @@ public class Region {
 
         public void setSingleNamespace(boolean singleNamespace) {
             this.singleNamespace = singleNamespace;
+        }
+
+        public void setDefaultConfiguration(Object defaultConfiguration) {
+            this.defaultConfiguration = defaultConfiguration;
+        }
+
+        public Object getDefaultConfiguration() {
+            return defaultConfiguration;
         }
 
         public boolean isAllowNamespaceCreation() {


### PR DESCRIPTION
Add a check at startup to ensure admin followed the API V3 (Onyxia V9) migration guide and moved away from `defaultConfiguration` in favor of JSON schema support