### PR TITLE
Add events webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,16 @@ Configurable properties :
 | `http.proxyPassword` | | Password if the proxy requires authentication |
 
 ### Events
-| Key | Default | Description                            |
-| --------------------- |---------|----------------------------------------|
-| `event.logging.enabled` | `true`  | whether events should be logged or not |
+| Key                      | Default | Description                                                        |
+|--------------------------|--|--------------------------------------------------------------------|
+| `event.logging.enabled`  | `true` | whether events should be logged or not                             |
+| `event.webhook.enabled`  | `false` | whether events should be sent to an external webhook via HTTP POST |
+| `event.webhook.url`      |  | URL of the webhook to send the events to                           |
+| `event.webhook.includes` |  | List of events types to send the webhook for (empty = all events). e.g `service.uninstall,service.install`                           |
+| `event.webhook.excludes` |  | List of events types to ignore for the webhook. e.g `service.uninstall,service.install`                           |
+
+
+
 
 ### Other configurations
 | Key | Default | Description |

--- a/README.md
+++ b/README.md
@@ -98,9 +98,6 @@ Configurable properties :
 | `event.webhook.includes` |  | List of events types to send the webhook for (empty = all events). e.g `service.uninstall,service.install`                           |
 | `event.webhook.excludes` |  | List of events types to ignore for the webhook. e.g `service.uninstall,service.install`                           |
 
-
-
-
 ### Other configurations
 | Key | Default | Description |
 | --------------------- | ------- | ------------------------------------------------------------------ |

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
@@ -2,9 +2,6 @@ package fr.insee.onyxia.api.events;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -18,6 +15,10 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @EnableAsync
 @Component
@@ -50,15 +51,11 @@ public class WebhookEventListener {
     @Async
     @EventListener
     public void onOnyxiaEvent(OnyxiaEvent onyxiaEvent) throws JsonProcessingException {
-        if (!includes.isEmpty()) {
-            if (!includes.contains(onyxiaEvent.getType())) {
-                return;
-            }
+        if (!includes.isEmpty() && !includes.contains(onyxiaEvent.getType())) {
+            return;
         }
-        if (!excludes.isEmpty()) {
-            if (excludes.contains(onyxiaEvent.getType())) {
-                return;
-            }
+        if (!excludes.isEmpty() && excludes.contains(onyxiaEvent.getType())) {
+            return;
         }
         RequestBody body = RequestBody.create(objectMapper.writeValueAsString(onyxiaEvent), JSON);
         Request request = new Request.Builder().url(url).post(body).build();

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
@@ -2,6 +2,9 @@ package fr.insee.onyxia.api.events;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -15,10 +18,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @EnableAsync
 @Component

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
@@ -2,6 +2,9 @@ package fr.insee.onyxia.api.events;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -15,10 +18,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 @EnableAsync
 @Component
@@ -62,10 +61,7 @@ public class WebhookEventListener {
             }
         }
         RequestBody body = RequestBody.create(objectMapper.writeValueAsString(onyxiaEvent), JSON);
-        Request request = new Request.Builder()
-                .url(url)
-                .post(body)
-                .build();
+        Request request = new Request.Builder().url(url).post(body).build();
         try {
             httpClient.newCall(request).execute();
         } catch (IOException e) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
@@ -2,9 +2,6 @@ package fr.insee.onyxia.api.events;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -18,6 +15,10 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @EnableAsync
 @Component
@@ -65,7 +66,7 @@ public class WebhookEventListener {
         try {
             httpClient.newCall(request).execute();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.warn("Failure while sending event to webhook, will not be retried", e);
         }
     }
 

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/events/WebhookEventListener.java
@@ -1,0 +1,107 @@
+package fr.insee.onyxia.api.events;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+@EnableAsync
+@Component
+@ConditionalOnProperty(name = "event.webhook.enabled", havingValue = "true")
+public class WebhookEventListener {
+
+    private final ObjectMapper objectMapper;
+
+    private static final MediaType JSON = MediaType.get("application/json");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebhookEventListener.class);
+
+    @Value("${event.webhook.url}")
+    private String url;
+
+    @Value("${event.webhook.includes}")
+    private List<String> includes = new ArrayList<>();
+
+    @Value("${event.webhook.excludes}")
+    private List<String> excludes = new ArrayList<>();
+
+    private final OkHttpClient httpClient;
+
+    @Autowired
+    public WebhookEventListener(ObjectMapper objectMapper, OkHttpClient okHttpClient) {
+        this.objectMapper = objectMapper;
+        this.httpClient = okHttpClient;
+    }
+
+    @Async
+    @EventListener
+    public void onOnyxiaEvent(OnyxiaEvent onyxiaEvent) throws JsonProcessingException {
+        if (!includes.isEmpty()) {
+            if (!includes.contains(onyxiaEvent.getType())) {
+                return;
+            }
+        }
+        if (!excludes.isEmpty()) {
+            if (excludes.contains(onyxiaEvent.getType())) {
+                return;
+            }
+        }
+        RequestBody body = RequestBody.create(objectMapper.writeValueAsString(onyxiaEvent), JSON);
+        Request request = new Request.Builder()
+                .url(url)
+                .post(body)
+                .build();
+        try {
+            httpClient.newCall(request).execute();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public List<String> getIncludes() {
+        return includes;
+    }
+
+    public void setIncludes(List<String> includes) {
+        this.includes = includes;
+    }
+
+    public List<String> getExcludes() {
+        return excludes;
+    }
+
+    public void setExcludes(List<String> excludes) {
+        this.excludes = excludes;
+    }
+
+    public OkHttpClient getHttpClient() {
+        return httpClient;
+    }
+}

--- a/onyxia-api/src/main/resources/application.properties
+++ b/onyxia-api/src/main/resources/application.properties
@@ -29,5 +29,13 @@ springdoc.swagger-ui.oauth.clientId=
 springdoc.swagger-ui.oauth.clientSecret=
 # Enable events logging
 event.logging.enabled=true
+# Enable events webhook
+event.webhook.enabled=false
+# URL to send the events to
+event.webhook.url=
+# List of events types to send the webhook for (empty = all events). e.g service.uninstall,service.install
+event.webhook.includes=
+# List of events types to ignore for the webhook. e.g service.uninstall,service.install
+event.webhook.excludes=
 # Response stream configuration
 spring.mvc.async.request-timeout=600000


### PR DESCRIPTION
Currently, the events can only be logged in the console.  
This PR adds the ability to enables webhooks for the events.  
If enabled, Onyxia-API will do a async POST request to the webhook url with the event content.  
Onyxia-API will NOT retry if the webhook backend suffers a temporary failure.  
