### PR TITLE
Remove unused key from regions.json: initScript 

### DIFF
--- a/onyxia-api/src/main/resources/regions.json
+++ b/onyxia-api/src/main/resources/regions.json
@@ -9,7 +9,6 @@
       },
       "services": {
         "type": "KUBERNETES",
-        "initScript": "https://git.lab.sspcloud.fr/innovation/plateforme-onyxia/services-ressources/-/raw/master/onyxia-init.sh",
         "singleNamespace": true,
         "namespacePrefix": "user-",
         "usernamePrefix": "oidc-",


### PR DESCRIPTION
Since version 9.0.0 of Onyxia (version 3.0.0 of Onyxia API), the initScript key is no longer used because the initialization script mechanism has been replaced by JSON schema overriding (https://docs.onyxia.sh/admin-doc/catalog-of-services#how-to-overwrite-a-schema-or-create-a-new-one).

Maybe, I'm wrong ...