### PR TITLE
Ignore SSE errors

### DIFF
--- a/onyxia-api/Dockerfile
+++ b/onyxia-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.4_7-jre as extract
+FROM eclipse-temurin:21.0.4_7-jre AS extract
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar  extract

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -362,12 +362,20 @@ public class MyLabController {
 
         @Override
         public void onClose() {
-            emitter.complete();
+            try {
+                emitter.complete();
+            } catch (Exception ignored) {
+
+            }
         }
 
         @Override
         public void onClose(WatcherException e) {
-            emitter.complete();
+            try {
+                emitter.complete();
+            } catch (Exception ignored) {
+
+            }
         }
     }
 


### PR DESCRIPTION
There are a lot of ways sending events can fail (e.g client has already closed the connection) and we don't really care if that happen as it's not relevant in most cases.  
This PR just ignores those errors