### PR TITLE
Fix helm install actions

### DIFF
--- a/onyxia-api/Dockerfile
+++ b/onyxia-api/Dockerfile
@@ -6,7 +6,9 @@ RUN java -Djarmode=layertools -jar application.jar  extract
 FROM eclipse-temurin:21.0.4_7-jre
 WORKDIR /app
 # Install helm
-RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | DESIRED_VERSION=v3.16.1 bash
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+RUN chmod +x get_helm.sh
+RUN DESIRED_VERSION=v3.16.1 ./get_helm.sh
 RUN groupadd --gid 101 --system onyxia && \
     useradd --system --uid 101 --create-home --home-dir /var/cache/onyxia --shell /sbin/nologin --gid onyxia --comment onyxia onyxia
 # Allow adding CA certificates

--- a/onyxia-api/Dockerfile
+++ b/onyxia-api/Dockerfile
@@ -6,9 +6,11 @@ RUN java -Djarmode=layertools -jar application.jar  extract
 FROM eclipse-temurin:21.0.4_7-jre
 WORKDIR /app
 # Install helm
-RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-RUN chmod +x get_helm.sh
-RUN DESIRED_VERSION=v3.16.1 ./get_helm.sh
+RUN wget https://get.helm.sh/helm-v3.16.1-linux-amd64.tar.gz
+RUN tar -zxvf helm-v3.16.1-linux-amd64.tar.gz
+RUN mv linux-amd64/helm /usr/local/bin/helm
+RUN rm helm-v3.16.1-linux-amd64.tar.gz
+RUN rm -rf linux-amd64
 RUN groupadd --gid 101 --system onyxia && \
     useradd --system --uid 101 --create-home --home-dir /var/cache/onyxia --shell /sbin/nologin --gid onyxia --comment onyxia onyxia
 # Allow adding CA certificates


### PR DESCRIPTION
For whatever reason, github actions docker build fails with error `url: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to get.helm.sh:443 ` for like a week now.  
I confirmed this was a github actions specific bug as the build was running just fine anywhere else.  
This PR installs helm another way