### PR TITLE
Filter catalog services based on keywords

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/configuration/CatalogWrapper.java
@@ -51,6 +51,9 @@ public class CatalogWrapper {
     @Schema(description = "names of declarative important charts of the catalog")
     private List<String> highlightedCharts = new ArrayList<>();
 
+    @Schema(description = "only include charts with one or more of the given keywords")
+    private List<String> includeKeywords = new ArrayList<>();
+
     @Schema(description = "Skip tls certificate checks for the repository")
     private boolean skipTlsVerify;
 
@@ -192,6 +195,14 @@ public class CatalogWrapper {
 
     public void setHighlightedCharts(List<String> highlightedCharts) {
         this.highlightedCharts = highlightedCharts;
+    }
+
+    public List<String> getIncludeKeywords() {
+        return includeKeywords;
+    }
+
+    public void setIncludeKeywords(List<String> includeKeywords) {
+        this.includeKeywords = includeKeywords;
     }
 
     public boolean getSkipTlsVerify() {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogLoader.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogLoader.java
@@ -76,7 +76,8 @@ public class CatalogLoader {
                                                                     excludedChart.equalsIgnoreCase(
                                                                             key)))
                             .filter(
-                                    // If includeKeywords is defined, only include services where the latest version
+                                    // If includeKeywords is defined, only include services where
+                                    // the latest version
                                     // has the desired keyword.
                                     key ->
                                             cw.getIncludeKeywords() == null

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogLoaderTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogLoaderTest.java
@@ -3,7 +3,7 @@ package fr.insee.onyxia.api.dao.universe;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import fr.insee.onyxia.api.configuration.CatalogWrapper;
 import fr.insee.onyxia.api.configuration.CustomObjectMapper;
@@ -12,6 +12,7 @@ import fr.insee.onyxia.api.services.JsonSchemaResolutionService;
 import fr.insee.onyxia.api.util.TestUtils;
 import fr.insee.onyxia.model.helm.Chart;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -151,5 +152,15 @@ public class CatalogLoaderTest {
                         "fr.insee.onyxia.api.dao.universe.CatalogLoaderException: "
                                 + "Exception occurred during loading resource: class path resource "
                                 + "[catalog-loader-test/keepeme1.gz]"));
+    }
+
+    @Test
+    void filterIncludeKeywordsTest() {
+        CatalogWrapper cw = new CatalogWrapper();
+        cw.setType("helm");
+        cw.setLocation("classpath:/catalog-loader-test-with-keywords");
+        cw.setIncludeKeywords(List.of("CD"));
+        catalogLoader.updateCatalog(cw);
+        assertEquals(Set.of("keepme"), cw.getCatalog().getEntries().keySet());
     }
 }

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogLoaderTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/dao/universe/CatalogLoaderTest.java
@@ -16,14 +16,12 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ResourceLoader;
@@ -178,7 +176,6 @@ public class CatalogLoaderTest {
                 arguments(List.of("CD", "Experimental"), Set.of("keepme", "excludeme")),
                 arguments(List.of(), Set.of("keepme", "excludeme")),
                 arguments(null, Set.of("keepme", "excludeme")),
-                arguments(List.of("no one knows"), Set.of())
-        );
+                arguments(List.of("no one knows"), Set.of()));
     }
 }

--- a/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/catalogs.json5
+++ b/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/catalogs.json5
@@ -1,0 +1,36 @@
+// This file is a json5-file, which onyxia-api should be able to parse
+{
+  "catalogs": [
+    {
+      "id": "ide",
+      "name": "IDE",
+      "description": "Services for datascientists.",
+      "maintainer": "innovation@insee.fr",
+      "location": "https://inseefrlab.github.io/helm-charts-interactive-services",
+      "status": "PROD",
+      "highlightedCharts": ["jupyter-python", "rstudio", "vscode-python"],
+      // Single quote should be supported
+      "timeout": '10m',
+      "type": 'helm',
+      /* block comment
+      over several
+      lines are supported */
+      "skipTlsVerify": false,
+      "caFile": null,
+      "allowSharing": false,
+      "visible": {
+        "user": true,
+        // Trailing comma is supported
+        "project": true,
+      },
+      "restrictions": [
+        {
+          "userAttribute": {
+            "key": "sub",
+            "match": "^onyxia.*"
+          }
+        }
+      ]
+    },
+  ],
+}

--- a/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/index.yaml
+++ b/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/index.yaml
@@ -15,8 +15,6 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
-      keywords:
-        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -42,8 +40,6 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
-      keywords:
-        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -69,8 +65,6 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
-      keywords:
-        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -95,8 +89,6 @@ entries:
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
       name: excludeme
-      keywords:
-        - Experimental
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
         - https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd
@@ -119,8 +111,6 @@ entries:
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
       name: excludeme
-      keywords:
-        - Experimental
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
         - https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd
@@ -128,3 +118,4 @@ entries:
       urls:
         - excludeme2.gz
       version: 2.4.0
+

--- a/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/index.yaml
+++ b/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/index.yaml
@@ -121,6 +121,7 @@ entries:
       name: excludeme
       keywords:
         - Experimental
+        - CD
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
         - https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd

--- a/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/index.yaml
+++ b/onyxia-api/src/test/resources/catalog-loader-test-with-keywords/index.yaml
@@ -15,6 +15,8 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
+      keywords:
+        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -40,6 +42,8 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
+      keywords:
+        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -65,6 +69,8 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
+      keywords:
+        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -89,6 +95,8 @@ entries:
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
       name: excludeme
+      keywords:
+        - Experimental
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
         - https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd
@@ -111,6 +119,8 @@ entries:
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
       name: excludeme
+      keywords:
+        - Experimental
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
         - https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd
@@ -118,4 +128,3 @@ entries:
       urls:
         - excludeme2.gz
       version: 2.4.0
-

--- a/onyxia-api/src/test/resources/catalog-loader-test/index.yaml
+++ b/onyxia-api/src/test/resources/catalog-loader-test/index.yaml
@@ -15,8 +15,6 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
-      keywords:
-        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -42,8 +40,6 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
-      keywords:
-        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -69,8 +65,6 @@ entries:
       digest: beedc71c7f5730cf68000b5665dd4da636e72a026edd9b12c1d048398d4166dd
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
-      keywords:
-        - CD
       name: keepme
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
@@ -95,8 +89,6 @@ entries:
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
       name: excludeme
-      keywords:
-        - Experimental
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
         - https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd
@@ -119,8 +111,6 @@ entries:
       home: https://argo-cd.readthedocs.io/en/stable/
       icon: https://minio.lab.sspcloud.fr/projet-onyxia/assets/servicesImg/argo.png
       name: excludeme
-      keywords:
-        - Experimental
       sources:
         - https://github.com/InseeFrLab/helm-charts-datascience/tree/master/charts/argo-cd
         - https://github.com/argoproj/argo-helm/tree/master/charts/argo-cd
@@ -128,3 +118,4 @@ entries:
       urls:
         - excludeme2.gz
       version: 2.4.0
+


### PR DESCRIPTION
Allow exposing only a subset of services in a Helm repo based on keywords specified on the services' Helm Chart. Only the keywords on the latest version of the Helm Chart are considered to allow simple modification of which services are exposed.

Resolves #519 
