### PR TITLE
Fabric8 k8s client : revert to OkHTTPClient

### DIFF
--- a/helm-wrapper/pom.xml
+++ b/helm-wrapper/pom.xml
@@ -61,7 +61,21 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-vertx</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-okhttp</artifactId>
+            <version>7.0.0</version>
+            <scope>runtime</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
See https://github.com/fabric8io/kubernetes-client/blob/main/doc/MIGRATION-v7.md#vertx-httpclient  

Migration does not appear to be seamless for us (will probably get better when we reduce resource consumption and leaks by mutualizing and properly closing clients after use) so let's stick with httpclient for now