### PR TITLE
Allow JMX debug

### DIFF
--- a/onyxia-api/entrypoint.sh
+++ b/onyxia-api/entrypoint.sh
@@ -13,4 +13,9 @@ if [[ -n "$CACERTS_DIR" ]]; then
 fi
 
 # Run application
-java org.springframework.boot.loader.launch.JarLauncher
+if [ -n "$DEBUG_JMX" ]; then
+  JMX_PORT="${JMX_PORT:-10000}"
+  java -Dcom.sun.management.jmxremote.port=$JMX_PORT -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false org.springframework.boot.loader.launch.JarLauncher
+else
+  java org.springframework.boot.loader.launch.JarLauncher
+fi


### PR DESCRIPTION
This PR allows admins to enable JMX debugging to monitor the Java process.  
This feature is mainly for Onyxia devs for ease when working on optimisations

* [ ] Add the env variables to the documentation