### PR TITLE
RFC9457 exploratory code for error propagation

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/RestExceptionHandler.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/RestExceptionHandler.java
@@ -1,36 +1,64 @@
 package fr.insee.onyxia.api.controller;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.everit.json.schema.ValidationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.everit.json.schema.ValidationException;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
-public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+public class RestExceptionHandler {
 
+    // Helper method to create ProblemDetail
+    private ProblemDetail createProblemDetail(HttpStatus status, URI type, String title, String detail, String instancePath) {
+        ProblemDetail problemDetail = ProblemDetail.forStatus(status);
+        problemDetail.setType(type);
+        problemDetail.setTitle(title);
+        problemDetail.setDetail(detail);
+        problemDetail.setInstance(URI.create(instancePath));
+        return problemDetail;
+    }
+
+    // AccessDeniedException handler
     @ExceptionHandler(AccessDeniedException.class)
-    public ProblemDetail handleAccessDeniedException(Exception ignored) {
-        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.FORBIDDEN);
-        problemDetail.setTitle("Access denied");
-        return problemDetail;
+    public ProblemDetail handleAccessDeniedException(AccessDeniedException exception, HttpServletRequest request) {
+        return createProblemDetail(
+                HttpStatus.FORBIDDEN,
+                RestExceptionTypes.ACCESS_DENIED,
+                "Access Denied",
+                "You do not have permission to access this resource.",
+                request.getRequestURI()
+        );
     }
 
+    // ValidationException handler
     @ExceptionHandler(ValidationException.class)
-    public ProblemDetail handleValidationException(ValidationException ex) {
-        List<String> errors =
-                ex.getCausingExceptions().stream()
-                        .map(ValidationException::getMessage)
-                        .collect(Collectors.toList());
+    public ProblemDetail handleValidationException(ValidationException ex, HttpServletRequest request) {
+        List<String> errors = ex.getCausingExceptions() != null && !ex.getCausingExceptions().isEmpty()
+                ? ex.getCausingExceptions().stream()
+                    .map(ValidationException::getMessage)
+                    .collect(Collectors.toList())
+                : List.of(ex.getMessage()); // Fallback to the main exception message if causing exceptions are empty.
 
-        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
-        problemDetail.setProperties(Map.of("errors", errors));
-        problemDetail.setTitle("Validation failed");
+        ProblemDetail problemDetail = createProblemDetail(
+                HttpStatus.BAD_REQUEST,
+                RestExceptionTypes.VALIDATION_FAILED,
+                "Validation Failed",
+                "The request contains invalid data.",
+                request.getRequestURI()
+        );
+
+        // Add 'errors' as a custom property
+        problemDetail.setProperty("errors", errors);
         return problemDetail;
     }
+
+    
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/RestExceptionTypes.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/RestExceptionTypes.java
@@ -1,0 +1,19 @@
+package fr.insee.onyxia.api.controller;
+
+import java.net.URI;
+
+// These are mostly examples
+public class RestExceptionTypes {
+    public static final URI ACCESS_DENIED = URI.create("urn:org:onyxia:api:error:access-denied");
+    public static final URI VALIDATION_FAILED = URI.create("urn:org:onyxia:api:error:validation-failed");
+    public static final URI INVALID_ARGUMENT = URI.create("urn:org:onyxia:api:error:invalid-argument");
+    public static final URI INSTALLATION_FAILURE = URI.create("urn:org:onyxia:api:error:installation-failure");
+    public static final URI NAMESPACE_NOT_FOUND = URI.create("urn:org:onyxia:api:error:namespace-not-found");
+    public static final URI HELM_LIST_FAILURE = URI.create("urn:org:onyxia:api:error:helm-list-failure");
+    public static final URI HELM_RELEASE_FETCH_FAILURE = URI.create("urn:org:onyxia:api:error:helm-release-fetch-failure");
+    public static final URI GENERIC_ERROR = URI.create("urn:org:onyxia:api:error:unknown-error");
+
+    private RestExceptionTypes() {
+        // Prevent instantiation
+    }
+}

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/exception/CustomKubernetesException.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/exception/CustomKubernetesException.java
@@ -1,0 +1,31 @@
+package fr.insee.onyxia.api.controller.exception;
+
+import org.springframework.http.ProblemDetail;
+
+/**
+ * Custom exception class for propagating Kubernetes-related errors
+ * with structured ProblemDetail information.
+ */
+public class CustomKubernetesException extends RuntimeException {
+    
+    private final ProblemDetail problemDetail;
+
+    /**
+     * Constructor to create a CustomKubernetesException.
+     * 
+     * @param problemDetail The ProblemDetail containing error details
+     */
+    public CustomKubernetesException(ProblemDetail problemDetail) {
+        super(problemDetail.getDetail());
+        this.problemDetail = problemDetail;
+    }
+
+    /**
+     * Getter for the ProblemDetail object.
+     * 
+     * @return ProblemDetail containing structured error details
+     */
+    public ProblemDetail getProblemDetail() {
+        return problemDetail;
+    }
+}

--- a/onyxia-api/src/test/java/fr/insee/onyxia/api/controller/RestExceptionHandlerTest.java
+++ b/onyxia-api/src/test/java/fr/insee/onyxia/api/controller/RestExceptionHandlerTest.java
@@ -1,0 +1,89 @@
+package fr.insee.onyxia.api.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.AccessDeniedException;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+
+class RestExceptionHandlerTest {
+
+    private RestExceptionHandler restExceptionHandler;
+    private HttpServletRequest mockRequest;
+
+    @BeforeEach
+    void setUp() {
+        restExceptionHandler = new RestExceptionHandler();
+        mockRequest = Mockito.mock(HttpServletRequest.class);
+    }
+
+    @Test
+    void testHandleAccessDeniedForNamespaceCreation() {
+        when(mockRequest.getRequestURI()).thenReturn("/onboarding");
+
+        AccessDeniedException exception = new AccessDeniedException("Access Denied for Namespace Creation");
+        ProblemDetail result = restExceptionHandler.handleAccessDeniedException(exception, mockRequest);
+
+        assertEquals(HttpStatus.FORBIDDEN.value(), result.getStatus());
+        assertEquals(RestExceptionTypes.ACCESS_DENIED, result.getType());
+        assertEquals("Access Denied", result.getTitle());
+        assertEquals("You do not have permission to access this resource.", result.getDetail());
+        assertEquals(URI.create("/onboarding"), result.getInstance());
+    }
+
+    @Test
+    void testHandleValidationException() {
+        when(mockRequest.getRequestURI()).thenReturn("/my-lab/app");
+
+        ValidationException validationException = Mockito.mock(ValidationException.class);
+        when(validationException.getMessage()).thenReturn("Validation Error Message");
+
+        ProblemDetail result = restExceptionHandler.handleValidationException(validationException, mockRequest);
+
+        assertEquals(HttpStatus.BAD_REQUEST.value(), result.getStatus());
+        assertEquals(RestExceptionTypes.VALIDATION_FAILED, result.getType());
+        assertEquals("Validation Failed", result.getTitle());
+        assertEquals("The request contains invalid data.", result.getDetail());
+        assertEquals(URI.create("/my-lab/app"), result.getInstance());
+        assertThat(result.getProperties()).containsKey("errors");
+    }
+
+    @Test
+    void testHandleValidationExceptionWithErrors() {
+        when(mockRequest.getRequestURI()).thenReturn("/my-lab/app");
+        
+        Schema mockSchema = Mockito.mock(Schema.class);
+
+        ValidationException ex1 = new ValidationException(mockSchema, "Field 'name' is required","name");
+        ValidationException ex2 = new ValidationException(mockSchema, "Field 'version' must be a number","version");
+
+        ValidationException validationException = Mockito.mock(ValidationException.class);
+        when(validationException.getMessage()).thenReturn("Validation Error Message");
+        when(validationException.getCausingExceptions()).thenReturn(List.of(ex1, ex2));
+
+        ProblemDetail result = restExceptionHandler.handleValidationException(validationException, mockRequest);
+
+        assertEquals(HttpStatus.BAD_REQUEST.value(), result.getStatus());
+        assertEquals(RestExceptionTypes.VALIDATION_FAILED, result.getType());
+        assertEquals("Validation Failed", result.getTitle());
+        assertEquals("The request contains invalid data.", result.getDetail());
+        assertEquals(URI.create("/my-lab/app"), result.getInstance());
+
+        @SuppressWarnings("unchecked")
+        List<String> errors = (List<String>) result.getProperties().get("errors");
+        assertThat(errors).containsExactly(
+                "#: Field 'name' is required",
+                "#: Field 'version' must be a number");
+    }
+}


### PR DESCRIPTION
* Sample RestExceptionHandler for standardizing error propagation
* Added an example of standardised errors that can be handled
* Implementet this error propagation in a few classes as an example
* Added a test for the RestExceptionHandler

This code is **not intended to be merged as is**, but meant as an example of rfc9457 implementation. It was better to put it here, than have it uncommitted on my hard drive. 
