### PR TITLE
extraenv.json : remove items title

### DIFF
--- a/onyxia-api/src/main/resources/schemas/ide/extraenv.json
+++ b/onyxia-api/src/main/resources/schemas/ide/extraenv.json
@@ -5,7 +5,7 @@
     "type": "array",
     "default": [],
     "items": {
-      "title": "environment variable",
+      "title": "",
       "type": "object",
       "properties": {
         "name": {


### PR DESCRIPTION
This is a partial revert of #556 to remove individual titles of items as it crowds the UI too much
