### PR TITLE
Support packages with no schemas

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/mylab/MyLabController.java
@@ -29,16 +29,15 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 @Tag(name = "My lab", description = "My services")
 @RequestMapping("/my-lab")


### PR DESCRIPTION
Currently, if no `values.schema.json` is provided then the API fails with 500 when resolving the schema.  
This PR adds support for packages with no schema :  
* GET /my-lab/schemas/xxx : returns 200 empty if no schema is defined  
* PUT /my-lab/app : skip schema validation if no schema is defined