### PR TITLE
Add user profile schema

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/profile/ProfileController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/profile/ProfileController.java
@@ -1,0 +1,33 @@
+package fr.insee.onyxia.api.controller.api.profile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import fr.insee.onyxia.api.services.UserProvider;
+import fr.insee.onyxia.model.User;
+import fr.insee.onyxia.model.region.Region;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Profile", description = "Info on profile configuration feature")
+@RequestMapping("/profile")
+@RestController
+@SecurityRequirement(name = "auth")
+public class ProfileController {
+
+    private final UserProvider userProvider;
+
+    @Autowired
+    public ProfileController(UserProvider userProvider) {
+        this.userProvider = userProvider;
+    }
+
+    @GetMapping("schema")
+    public JsonNode profileSchema(@Parameter(hidden = true) Region region) {
+        User user = userProvider.getUser(region);
+        return jsonSchemaResolutionService.resolveReferences(chart.getConfig(), user.getRoles());
+    }
+}

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/profile/ProfileController.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/controller/api/profile/ProfileController.java
@@ -1,6 +1,7 @@
 package fr.insee.onyxia.api.controller.api.profile;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import fr.insee.onyxia.api.services.JsonSchemaProfileRegistryService;
 import fr.insee.onyxia.api.services.UserProvider;
 import fr.insee.onyxia.model.User;
 import fr.insee.onyxia.model.region.Region;
@@ -20,14 +21,19 @@ public class ProfileController {
 
     private final UserProvider userProvider;
 
+    private final JsonSchemaProfileRegistryService jsonSchemaProfileRegistryService;
+
     @Autowired
-    public ProfileController(UserProvider userProvider) {
+    public ProfileController(
+            UserProvider userProvider,
+            JsonSchemaProfileRegistryService jsonSchemaProfileRegistryService) {
         this.userProvider = userProvider;
+        this.jsonSchemaProfileRegistryService = jsonSchemaProfileRegistryService;
     }
 
     @GetMapping("schema")
     public JsonNode profileSchema(@Parameter(hidden = true) Region region) {
         User user = userProvider.getUser(region);
-        return jsonSchemaResolutionService.resolveReferences(chart.getConfig(), user.getRoles());
+        return jsonSchemaProfileRegistryService.getProfileSchema();
     }
 }

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/JsonSchemaProfileRegistryService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/JsonSchemaProfileRegistryService.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,14 +25,13 @@ public class JsonSchemaProfileRegistryService {
 
     private ObjectMapper objectMapper = new ObjectMapper();
 
-    public JsonSchemaProfileRegistryService() {
-        loadProfileSchema();
-    }
+    public JsonSchemaProfileRegistryService() {}
 
     public JsonNode getProfileSchema() {
         return defaultProfileSchema;
     }
 
+    @PostConstruct
     private void loadProfileSchema() {
         Path roleSchemaPath = Paths.get(userProfileDirectory);
         if (Files.exists(roleSchemaPath) && Files.exists(roleSchemaPath.resolve("default"))) {

--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/services/JsonSchemaProfileRegistryService.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/services/JsonSchemaProfileRegistryService.java
@@ -1,0 +1,46 @@
+package fr.insee.onyxia.api.services;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JsonSchemaProfileRegistryService {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(JsonSchemaProfileRegistryService.class);
+
+    @Value("${profile.schema.directory:/userProfile}") // External directory path
+    private String userProfileDirectory;
+
+    private JsonNode defaultProfileSchema;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    public JsonSchemaProfileRegistryService() {
+        loadProfileSchema();
+    }
+
+    public JsonNode getProfileSchema() {
+        return defaultProfileSchema;
+    }
+
+    private void loadProfileSchema() {
+        Path roleSchemaPath = Paths.get(userProfileDirectory);
+        if (Files.exists(roleSchemaPath) && Files.exists(roleSchemaPath.resolve("default"))) {
+            try {
+                JsonNode schema = objectMapper.readTree(roleSchemaPath.resolve("default").toFile());
+                defaultProfileSchema = schema;
+            } catch (IOException e) {
+                LOGGER.error("User profile : failed to load default profile", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is an implementation of https://github.com/InseeFrLab/onyxia/discussions/954 

Adds a new endpoint : `/profile/schema` that returns a JSON schema specifying the user profile fields.  
Todo : add support for user profile based on User's role  

Note : this PR comes alongside a new helm chart update that is currently dev here : https://github.com/InseeFrLab/helm-charts-dev/tree/main/charts/onyxia  
