### PR TITLE
Sort chart versions

### DIFF
--- a/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogLoader.java
+++ b/onyxia-api/src/main/java/fr/insee/onyxia/api/dao/universe/CatalogLoader.java
@@ -1,5 +1,7 @@
 package fr.insee.onyxia.api.dao.universe;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -11,6 +13,11 @@ import fr.insee.onyxia.api.configuration.CatalogWrapper;
 import fr.insee.onyxia.model.catalog.Pkg;
 import fr.insee.onyxia.model.helm.Chart;
 import fr.insee.onyxia.model.helm.Repository;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.stream.Collectors;
 import okhttp3.CacheControl;
 import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
@@ -29,14 +36,6 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Service
 public class CatalogLoader {
@@ -154,10 +153,10 @@ public class CatalogLoader {
     }
 
     private void sortChartsListByVersion(List<Chart> charts, CatalogWrapper cw) {
-        charts.sort(Comparator.comparing(
-                chart -> Version.tryParse(chart.getVersion()).orElse(Version.of(0,0,0)),
-                Comparator.reverseOrder()
-        ));
+        charts.sort(
+                Comparator.comparing(
+                        chart -> Version.tryParse(chart.getVersion()).orElse(Version.of(0, 0, 0)),
+                        Comparator.reverseOrder()));
     }
 
     private void epurateChartsList(List<Chart> charts, CatalogWrapper cw) {


### PR DESCRIPTION
Currently, Onyxia has the assumption that the list of packages is sorted by versions (desc) which may not be the case depending on the helm registry provider (for example, it seems gitlab recently broke the sorting and now sorts in asc order).  
This PR adds a sort to ensure the list is always sorted desc by version